### PR TITLE
Remove extra forward slash from css compiler

### DIFF
--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -7,7 +7,7 @@ class Propshaft::Compilers::CssAssetUrls
 
   def compile(input)
     input.gsub(/asset-path\(["']([^"')]+)["']\)/) do |match|
-      %[url("/#{assembly.config.prefix}/#{assembly.load_path.find($1).digested_path}")]
+      %[url("#{assembly.config.prefix}/#{assembly.load_path.find($1).digested_path}")]
     end
   end
 end

--- a/test/propshaft/compilers_test.rb
+++ b/test/propshaft/compilers_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "propshaft/asset"
+require "propshaft/assembly"
 require "propshaft/compilers"
 
 class Propshaft::CompilersTest < ActiveSupport::TestCase
@@ -13,7 +14,7 @@ class Propshaft::CompilersTest < ActiveSupport::TestCase
 
   test "replace asset-path function in css with digested url" do
     @assembly.compilers.register "text/css", Propshaft::Compilers::CssAssetUrls
-    assert_match /archive-[a-z0-9]{40}.svg/, @assembly.compilers.compile(find_asset("another.css"))
+    assert_match /"\/assets\/archive-[a-z0-9]{40}.svg/, @assembly.compilers.compile(find_asset("another.css"))
   end
 
   private


### PR DESCRIPTION
It was generating this:
```css
background-image: url("//assets/archive-a6f92594e98de3bf5c5bd25ee51fb1bdc04e55e8.svg");
```