### PR TITLE
Serve pre digested files and add tests

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -32,6 +32,10 @@ class Propshaft::Asset
     end
   end
 
+  def fresh?(digest)
+    self.digest == digest || already_digested?
+  end
+
   def ==(other_asset)
     logical_path.hash == other_asset.logical_path.hash
   end

--- a/test/fixtures/assets/vendor/foobar/source/test.css
+++ b/test/fixtures/assets/vendor/foobar/source/test.css
@@ -1,0 +1,1 @@
+.hero { background: url(file.jpg) }

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -21,6 +21,13 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     assert_equal "f2e1ec14d6856e1958083094170ca6119c529a73", find_asset("one.txt").digest
   end
 
+  test "fresh" do
+    assert find_asset("one.txt").fresh?("f2e1ec14d6856e1958083094170ca6119c529a73")
+    assert_not find_asset("one.txt").fresh?("e206c34fe404c8e2f25d60dd8303f61c02b8d381")
+
+    assert find_asset("file-already-abcdef0123456789.digested.css").fresh?(nil)
+  end
+
   test "digested path" do
     assert_equal "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt",
       find_asset("one.txt").digested_path.to_s

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+require "propshaft/assembly"
+require "propshaft/server"
+
+class Propshaft::ServerTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  setup do
+    @assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config|
+      config.paths = [Pathname.new("#{__dir__}/../fixtures/assets/vendor"), Pathname.new("#{__dir__}/../fixtures/assets/first_path")]
+      config.output_path = Pathname.new("#{__dir__}../fixtures/output")
+    })
+
+    @assembly.compilers.register "text/css", Propshaft::Compilers::CssAssetUrls
+    @server = Propshaft::Server.new(@assembly)
+  end
+
+  test "serve a compiled file" do
+    asset = @assembly.load_path.find("foobar/source/test.css")
+    get "/#{asset.digested_path}"
+
+    assert_equal 200, last_response.status
+    assert_equal "94", last_response.headers['Content-Length']
+    assert_equal "text/css", last_response.headers['Content-Type']
+    assert_equal "Vary", last_response.headers['Accept-Encoding']
+    assert_equal asset.digest, last_response.headers['ETag']
+    assert_equal "public, max-age=31536000, immutable", last_response.headers['Cache-Control']
+    assert_equal ".hero { background: url(\"/foobar/source/file-3e6a129785ee3caf8eff23db339997e85334bfa9.jpg\") }\n",
+                 last_response.body
+  end
+
+  test "serve a predigested file" do
+    asset = @assembly.load_path.find("file-already-abcdef0123456789.digested.css")
+    get "/#{asset.digested_path}"
+    assert_equal 200, last_response.status
+  end
+
+  test "not found" do
+    get "/not-found.js"
+
+    assert_equal 404, last_response.status
+    assert_equal "9", last_response.headers['Content-Length']
+    assert_equal "text/plain", last_response.headers['Content-Type']
+    assert_equal "Not found", last_response.body
+    assert_not last_response.headers.key?('Cache-Control')
+    assert_not last_response.headers.key?('ETag')
+    assert_not last_response.headers.key?('Accept-Encoding')
+  end
+
+  test "not found if digest does not match" do
+    asset = @assembly.load_path.find("foobar/source/test.css")
+    get "/#{asset.logical_path}"
+    assert_equal 404, last_response.status
+  end
+
+  private
+    def default_app
+      builder = Rack::Builder.new
+      builder.run @server
+    end
+
+    def app
+      @app ||= Rack::Lint.new(default_app)
+    end
+end


### PR DESCRIPTION
1. Ensure server can find pre digested files;
2. Add header `Content-Type` with `Vary` to ensure proper caching;
3. Add tests for server;
4. Add new method `stale?` to `asset`. Always returns `false` for predigested files.