### PR TITLE
Allow multiple extensions after .digested

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -42,6 +42,6 @@ class Propshaft::Asset
 
   private
     def already_digested?
-      logical_path.to_s =~ /-([0-9a-f]{7,128})\.digested\.[^.]+\z/
+      logical_path.to_s =~ /-([0-9a-f]{7,128})\.digested/
     end
 end

--- a/test/fixtures/assets/first_path/file-already-abcdef0123456789.digested.debug.css
+++ b/test/fixtures/assets/first_path/file-already-abcdef0123456789.digested.debug.css
@@ -1,0 +1,5 @@
+/* this is css */
+
+.btn {
+    background-image: asset-path("archive.svg");
+}

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -35,6 +35,9 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     assert_equal "file-already-abcdef0123456789.digested.css",
       find_asset("file-already-abcdef0123456789.digested.css").digested_path.to_s
 
+    assert_equal "file-already-abcdef0123456789.digested.debug.css",
+      find_asset("file-already-abcdef0123456789.digested.debug.css").digested_path.to_s
+
     assert_equal "file-not.digested-e206c34fe404c8e2f25d60dd8303f61c02b8d381.css",
       find_asset("file-not.digested.css").digested_path.to_s
   end


### PR DESCRIPTION
Current regex does not allow multiple extensions, so it won't work with source maps which are generated as `.js.map`