### PR TITLE
Add reveal task

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -43,6 +43,12 @@ class Propshaft::Assembly
       end
   end
 
+  def reveal
+    load_path.assets.each do |asset|
+      Propshaft.logger.info asset.logical_path
+    end
+  end
+
   private
     def manifest_path
       config.output_path.join(Propshaft::Processor::MANIFEST_FILENAME)

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -55,6 +55,11 @@ module Propshaft
         task clean: :environment do
           Rails.application.assets.processor.clean
         end
+
+        desc "Print all the assets available in config.assets.paths"
+        task reveal: :environment do
+          Rails.application.assets.reveal
+        end
       end
     end
 


### PR DESCRIPTION
Log all assets in the load paths.

I saw some `.coffee` files when I tested it and was a bit suprised. Now I'm wondering if this task should take an optional parameter to print `path` instead of `logical_path` so we can see where the asset is coming from, or if we should add another task to print all the paths from which Propshaft will pull assets from?