### PR TITLE
Raise `MissingAssetError` in `compute_asset_path` instead of each resolver

### DIFF
--- a/lib/propshaft.rb
+++ b/lib/propshaft.rb
@@ -7,5 +7,6 @@ module Propshaft
 end
 
 require "propshaft/assembly"
+require "propshaft/errors"
 require "propshaft/helper"
 require "propshaft/railtie"

--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "propshaft/errors"
 
 class Propshaft::Compilers::CssAssetUrls
   attr_reader :assembly

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -1,5 +1,5 @@
 module Propshaft::Helper
   def compute_asset_path(path, options = {})
-    Rails.application.assets.resolver.resolve(path)
+    Rails.application.assets.resolver.resolve(path) || raise(Propshaft::MissingAssetError.new(path))
   end
 end

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -1,5 +1,7 @@
-module Propshaft::Helper
-  def compute_asset_path(path, options = {})
-    Rails.application.assets.resolver.resolve(path) || raise(Propshaft::MissingAssetError.new(path))
+module Propshaft
+  module Helper
+    def compute_asset_path(path, options = {})
+      Rails.application.assets.resolver.resolve(path) || raise(MissingAssetError.new(path))
+    end
   end
 end

--- a/lib/propshaft/resolver/dynamic.rb
+++ b/lib/propshaft/resolver/dynamic.rb
@@ -9,8 +9,6 @@ module Propshaft::Resolver
     def resolve(logical_path)
       if asset = load_path.find(logical_path)
         File.join prefix, asset.digested_path
-      else
-        raise Propshaft::MissingAssetError.new(logical_path)
       end
     end
   end

--- a/lib/propshaft/resolver/static.rb
+++ b/lib/propshaft/resolver/static.rb
@@ -9,8 +9,6 @@ module Propshaft::Resolver
     def resolve(logical_path)
       if asset_path = parsed_manifest[logical_path]
         File.join prefix, asset_path
-      else
-        raise Propshaft::MissingAssetError.new(logical_path)
       end
     end
 

--- a/test/propshaft/resolver/dynamic_test.rb
+++ b/test/propshaft/resolver/dynamic_test.rb
@@ -12,9 +12,7 @@ class Propshaft::Resolver::DynamicTest < ActiveSupport::TestCase
       @resolver.resolve("one.txt")
   end
 
-  test "resolving missing asset raises a custom error" do
-    assert_raise Propshaft::MissingAssetError do
-      assert_nil @resolver.resolve("nowhere.txt")
-    end
+  test "resolving missing asset returns nil" do
+    assert_nil @resolver.resolve("nowhere.txt")
   end
 end

--- a/test/propshaft/resolver/static_test.rb
+++ b/test/propshaft/resolver/static_test.rb
@@ -15,9 +15,7 @@ class Propshaft::Resolver::StaticTest < ActiveSupport::TestCase
       @resolver.resolve("one.txt")
   end
 
-  test "resolving missing asset raises a custom error" do
-    assert_raise Propshaft::MissingAssetError do
-      assert_nil @resolver.resolve("nowhere.txt")
-    end
+  test "resolving missing asset returns nil" do
+    assert_nil @resolver.resolve("nowhere.txt")
   end
 end


### PR DESCRIPTION
In https://github.com/rails/importmap-rails/issues/42#issuecomment-929844040 I wrote:

> I was looking further into this and noticed that, unlike sprockets-rails, in Propshaft's `compute_asset_path` helper we don't seem to raise if an asset isn't found: [rails/propshaft@`e07841a`/lib/propshaft/helper.rb#L2-L4](https://github.com/rails/propshaft/blob/e07841a8f1b4e16d60393082996e1177152aca81/lib/propshaft/helper.rb#L2-L4)
> 
> If the resolvers return `nil` ([here](https://github.com/rails/propshaft/blob/e07841a8f1b4e16d60393082996e1177152aca81/lib/propshaft/resolver/static.rb#L10-L12) or [here](https://github.com/rails/propshaft/blob/e07841a8f1b4e16d60393082996e1177152aca81/lib/propshaft/resolver/dynamic.rb#L10-L12)), then so will `compute_asset_path`. That will make typos result in a tag like `<script src=""></script>`:
> 
> ![image](https://user-images.githubusercontent.com/1863540/135207938-c95cf03d-6470-40ee-81e6-670e94bd4254.png)
> 
> So I'm going to make PR into Propshaft to make such errors more noticeable (here's the PR where sprockets-rails did so: [rails/sprockets-rails#375](https://github.com/rails/sprockets-rails/pull/375))

Unfortunately, some things came up and I had to put off working on that. However, a week ago Breno opened #16 to ensure the resolvers `raise` instead of returning `nil`! While that fixed the issue of typos potentially going unnoticed, I'd like to propose a small refactor in this PR:

> We can also handle it by raising directly in Propshaft's `compute_asset_path` implementation. I believe that approach is preferable for a few reasons. The simplest reason is that it requires less code.
> 
> Additionally, because `compute_asset_path` is the entry point for anyone looking to understand how Propshaft integrations with the ActionView helpers, I think it's helpful to include the exception it raises right there in the method's definition. This is also consistent with sprockets-rails, which [raises `AssetNotFound` directly in its `compute_asset_path` implementation](https://github.com/rails/sprockets-rails/blob/118ce60b1ffeb7a85640661b014cd2ee3c4e3e56/lib/sprockets/rails/helper.rb#L84).
> 
> But most importantly, because `compute_asset_path` is the highest level of Propshaft's integration with Rails (i.e. [the layer just before it hands results back to Rails](https://github.com/rails/rails/blob/099289b6360ac82d1e0fa0a5592ac10cfc05e6e0/actionview/lib/action_view/helpers/asset_url_helper.rb#L262-L268)), I believe it's safest to raise the missing asset error there. Consider a Propshaft extension which monkey patches one of the internal Resolver classes, or introduces a new one, in a way that makes it possible for `resolver.resolve` to return `nil` again. In that case, having the `raise` in `compute_asset_path` would still protect application developers by ensuring that the missing asset error is still surfaced. As a corollary, authors of such an extension wouldn't have to worry about raising `MissingAssetError` themselves since Propshaft would handle it.
> 
> Thus, I think it makes sense to move the `raise MissingAssetError` calls out of Propshaft's internal Resolver classes. Propshaft users aren't expected to interact directly with instances of those internal classes, so I think it's fine for their `resolve` methods to return `nil`, as the `if`-expressions naturally did prior to 0fd78144d70c987cf33da97b4b6471ca322b021e.

~As alluded to in https://github.com/rails/propshaft/pull/15#issuecomment-945878724, I also thought it would be valuable to add an integration test to ensure everything works as expected within an actual rails application. So, I added a basic integration test in 6ad6b241df55178e7692fb3eab6f1e02869965ee. (The other commits https://github.com/rails/propshaft/compare/88a684deae4d821201d1823ecbff538fb98effd7~...de2bf349c2023a509e55a51b35cde9747d8d0ef1 are just setup for the integration test which I split out since their large diffs distract from the real "meat" of this PR.)~ This was extracted to #44.