### PR TITLE
Ensure costly objects in assembly are memoized

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -18,7 +18,7 @@ class Propshaft::Assembly
   end
 
   def resolver
-    if manifest_path.exist?
+    @resolver ||= if manifest_path.exist?
       Propshaft::Resolver::Static.new manifest_path: manifest_path, prefix: config.prefix
     else
       Propshaft::Resolver::Dynamic.new load_path: load_path, prefix: config.prefix

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -21,7 +21,7 @@ class Propshaft::Asset
   end
 
   def digest
-    Digest::SHA1.hexdigest(content)
+    @digest ||= Digest::SHA1.hexdigest(content)
   end
 
   def digested_path

--- a/test/propshaft/assembly_test.rb
+++ b/test/propshaft/assembly_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "propshaft/assembly"
 require "active_support/ordered_options"
 
-class Propshaft::AssetTest < ActiveSupport::TestCase
+class Propshaft::AssemblyTest < ActiveSupport::TestCase
   test "uses static resolver when manifest is present" do
     assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config| 
       config.output_path = Pathname.new("#{__dir__}/../fixtures/output")
@@ -19,5 +19,15 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     })
 
     assert assembly.resolver.is_a?(Propshaft::Resolver::Dynamic)
+  end
+
+  test "costly methods are memoized" do
+    assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config|
+      config.output_path = Pathname.new("#{__dir__}/../fixtures/assets")
+      config.prefix = "/assets"
+    })
+
+    assert_equal assembly.resolver.object_id, assembly.resolver.object_id
+    assert_equal assembly.load_path.object_id, assembly.load_path.object_id
   end
 end

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -46,6 +46,11 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     assert_equal find_asset("one.txt"), find_asset("one.txt")
   end
 
+  test "costly methods are memoized" do
+    asset = find_asset("one.txt")
+    assert_equal asset.digest.object_id, asset.digest.object_id
+  end
+
   private
     def find_asset(logical_path)
       root_path = Pathname.new("#{__dir__}/../fixtures/assets/first_path")


### PR DESCRIPTION
The resolver is not currently memoized, which means every call to the static resolver causes it to parse the manifest file again.

The assets digest is not currently memoized, which means every call to the resolvers for an asset causes said asset to be read from the disk.