### PR TITLE
Benchmark resolvers

### DIFF
--- a/benchmarks/css_asset_urls
+++ b/benchmarks/css_asset_urls
@@ -1,32 +1,26 @@
 #!/usr/bin/env ruby
 
 # Benchmark file for the CssAssetUrls compiler
-#
-# It will download the free "StartBootstrap" theme to a temporary
-# folder and execute the compiler on it.
 
 require "active_support/ordered_options"
 require "benchmark/ips"
 require "open-uri"
 
+require_relative "./trackrod"
 require_relative "../lib/propshaft"
 require_relative "../lib/propshaft/compilers"
 require_relative "../lib/propshaft/compilers/css_asset_urls"
 
-dir = Dir.mktmpdir
-
-puts "Downloading startbootstrap-new-age benchmarking archive..."
-file = URI.parse("https://github.com/StartBootstrap/startbootstrap-new-age/archive/refs/heads/master.zip").open
-
-`unzip #{file.path} -d #{dir}`
+trackrod = Trackrod.new(Dir.mktmpdir)
+trackrod.build
 
 assets = ActiveSupport::OrderedOptions.new
-assets.paths     = [ dir + "/startbootstrap-new-age-master/dist" ]
+assets.paths     = [ trackrod.root ]
 assets.prefix    = "/assets"
 assets.compilers = [ [ "text/css", Propshaft::Compilers::CssAssetUrls ] ]
 
 assembly = Propshaft::Assembly.new(assets)
-asset    = assembly.load_path.find("css/styles.css")
+asset    = assembly.load_path.find(trackrod.assets.css)
 compiler = Propshaft::Compilers::CssAssetUrls.new(assembly)
 
 Benchmark.ips do |x|

--- a/benchmarks/dynamic_resolver
+++ b/benchmarks/dynamic_resolver
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# Benchmark file for the Dynamic resolver
+
+require "active_support/ordered_options"
+require "benchmark/ips"
+require "open-uri"
+
+require_relative "./trackrod"
+require_relative "../lib/propshaft"
+
+trackrod = Trackrod.new(Dir.mktmpdir)
+trackrod.build
+
+assets = ActiveSupport::OrderedOptions.new
+assets.paths         = [ trackrod.root ]
+assets.prefix        = "/assets"
+assets.compilers     = [ [ "text/css", Propshaft::Compilers::CssAssetUrls ] ]
+assets.output_path ||= Pathname.new(Dir.mktmpdir)
+
+assembly = Propshaft::Assembly.new(assets)
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("compile") { trackrod.assets.images.each { assembly.resolver.resolve _1 } }
+end

--- a/benchmarks/static_resolver
+++ b/benchmarks/static_resolver
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+# Benchmark file for the static resolver
+
+require "active_support/core_ext/string/access"
+require "active_support/ordered_options"
+require "benchmark/ips"
+
+require_relative "./trackrod"
+require_relative "../lib/propshaft"
+
+trackrod = Trackrod.new(Dir.mktmpdir)
+trackrod.build
+
+assets = ActiveSupport::OrderedOptions.new
+assets.paths         = [ trackrod.root ]
+assets.prefix        = "/assets"
+assets.compilers     = [ [ "text/css", Propshaft::Compilers::CssAssetUrls ] ]
+assets.output_path ||= Pathname.new(Dir.mktmpdir)
+
+assembly = Propshaft::Assembly.new(assets)
+assembly.processor.process
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("compile") { trackrod.assets.images.each { assembly.resolver.resolve _1 } }
+end

--- a/benchmarks/trackrod.rb
+++ b/benchmarks/trackrod.rb
@@ -1,0 +1,68 @@
+require "active_support/ordered_options"
+require 'fileutils'
+
+class Trackrod
+  attr_accessor :root, :images, :css, :javascript
+
+  def initialize(dir = nil)
+    @root       = dir || "#{Dir.getwd}/trackrod"
+    @images     = @root + "/images"
+    @css        = @root + "/stylesheets"
+    @javascript = @root + "/javascript"
+  end
+
+  def build
+    puts "Building Trackrod assets"
+
+    create_dir(root)
+    create_dir(images)
+    create_dir(css)
+    create_dir(javascript)
+
+    create_images
+    create_css
+    create_javascript
+  end
+
+  def assets
+    @assets ||= ActiveSupport::InheritableOptions.new(
+      css: "stylesheets/application.css",
+      js: "javascript/application.js",
+      images: (small_images + large_images).map { "images/#{_1}" }
+    )
+  end
+
+  private
+    def create_css
+      File.open("#{css}/application.css", "a") do |file|
+        small_images.each_with_index { |img, idx| file.write(background(img, idx)) }
+        large_images.each_with_index { |img, idx| file.write(background(img, idx)) }
+      end
+    end
+
+    def create_javascript
+    end
+
+    def create_images
+      small_images.each { |img| FileUtils.touch "#{images}/#{img}" }
+      large_images.each { |img| File.open("#{images}/#{img}", "a") { |file| file.write("a" * 2 ** 23) } unless File.exist?(img) }
+
+      nil
+    end
+
+    def small_images
+      @small_images ||= (1..5000).map { "s#{_1}.jpg" }
+    end
+
+    def large_images
+      @large_images ||= (1..100).map { "l#{_1}.jpg" }
+    end
+
+    def background(img, idx)
+      ".background_#{idx} {\n  background: url('../images/#{img}') \n}\n\n"
+    end
+
+    def create_dir(path)
+      Dir.mkdir(path) unless File.exist?(path)
+    end
+end


### PR DESCRIPTION
Add benchmarks for the two resolvers. Also replaces the css library we were using in the compiler benchmark for a class called `Trackrod` that can build a sufficiently large amount of 'fixtures' for proper benchmarking (5000 small files, 100 large files and a css file with 5000+ selectors). 