### PR TITLE
Rewrite CSS source map comments to include digest

### DIFF
--- a/benchmarks/css_asset_urls
+++ b/benchmarks/css_asset_urls
@@ -23,7 +23,10 @@ file = URI.parse("https://github.com/StartBootstrap/startbootstrap-new-age/archi
 assets = ActiveSupport::OrderedOptions.new
 assets.paths     = [ dir + "/startbootstrap-new-age-master/dist" ]
 assets.prefix    = "/assets"
-assets.compilers = [ [ "text/css", Propshaft::Compilers::CssAssetUrls ] ]
+assets.compilers = [
+  [ "text/css", Propshaft::Compilers::CssAssetUrls ],
+  [ "text/css", Propshaft::Compilers::CssSourceMap ]
+]
 
 assembly = Propshaft::Assembly.new(assets)
 asset    = assembly.load_path.find("css/styles.css")

--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -5,6 +5,7 @@ require "propshaft/server"
 require "propshaft/processor"
 require "propshaft/compilers"
 require "propshaft/compilers/css_asset_urls"
+require "propshaft/compilers/css_source_map"
 
 class Propshaft::Assembly
   attr_reader :config

--- a/lib/propshaft/compilers/css_source_map.rb
+++ b/lib/propshaft/compilers/css_source_map.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require "propshaft/errors"
+
+class Propshaft::Compilers::CssSourceMap
+  attr_reader :assembly
+
+  SOURCE_MAPPING_URL_PATTERN = /\/\*# sourceMappingURL=(.*\.map) \*\//
+
+  def initialize(assembly)
+    @assembly = assembly
+  end
+
+  def compile(logical_path, input)
+    input.gsub(SOURCE_MAPPING_URL_PATTERN) do
+      source_map_path = $1
+      logical_source_map_path = "#{logical_path.dirname}/#{source_map_path}"
+      source_map_asset = assembly.load_path.find(logical_source_map_path)
+
+      if not source_map_asset.nil?
+        source_mapping_url = source_map_asset.digested_path.basename
+        "/*# sourceMappingURL=#{source_mapping_url} */\n"
+      else
+        Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{logical_source_map_path}'"
+        nil
+      end
+    end
+  end
+end

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -16,7 +16,10 @@ module Propshaft
     config.assets = ActiveSupport::OrderedOptions.new
     config.assets.paths       = []
     config.assets.prefix      = "/assets"
-    config.assets.compilers   = [ [ "text/css", Propshaft::Compilers::CssAssetUrls ] ]
+    config.assets.compilers   = [
+      [ "text/css", Propshaft::Compilers::CssAssetUrls ],
+      [ "text/css", Propshaft::Compilers::CssSourceMap ]
+    ]
     config.assets.sweep_cache = Rails.env.development?
 
     config.after_initialize do |app|

--- a/test/fixtures/assets/vendor/foobar/source/test.css.map
+++ b/test/fixtures/assets/vendor/foobar/source/test.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":[]}

--- a/test/propshaft/compilers/css_source_map_test.rb
+++ b/test/propshaft/compilers/css_source_map_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+require "minitest/mock"
+require "propshaft/asset"
+require "propshaft/assembly"
+require "propshaft/compilers"
+
+class Propshaft::Compilers::CssSourceMapTest < ActiveSupport::TestCase
+  setup do
+    @assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config| 
+      config.paths = [ Pathname.new("#{__dir__}/../../fixtures/assets/vendor") ]
+      config.output_path = Pathname.new("#{__dir__}/../../fixtures/output")
+      config.prefix = "/assets"
+    })
+
+    @assembly.compilers.register "text/css", Propshaft::Compilers::CssSourceMap
+  end
+
+  test "no sourcemap" do
+    compiled = compile_asset_with_content(<<~EOF)
+      .hero { background: url(file.jpg); }
+    EOF
+    assert_equal <<~EOF, compiled
+      .hero { background: url(file.jpg); }
+    EOF
+  end
+
+  test "missing source map" do
+    compiled = compile_asset_with_content(<<~EOF)
+      .hero { background: url(file.jpg); }
+      /*# sourceMappingURL=missing.css.map */
+    EOF
+    assert_equal <<~EOF, compiled
+      .hero { background: url(file.jpg); }
+
+    EOF
+  end
+
+  test "present source map" do
+    compiled = compile_asset_with_content(<<~EOF)
+      .hero { background: url(file.jpg); }
+      /*# sourceMappingURL=test.css.map */
+    EOF
+    assert_match %r[.hero { background: url\(file\.jpg\); }\n/\*# sourceMappingURL=test\.css-[a-z0-9]{40}\.map \*/], compiled
+  end
+
+  private
+    def compile_asset_with_content(content)
+      root_path    = Pathname.new("#{__dir__}/../../fixtures/assets/vendor")
+      logical_path = "foobar/source/test.css"
+
+      asset     = Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path)
+      asset.stub :content, content do
+        @assembly.compilers.compile(asset)
+      end
+    end
+end


### PR DESCRIPTION
Similar to https://github.com/rails/sprockets-rails/pull/479/files

This was the only thing that prevented propshaft from being plug and play for us.

This only applies to CSS, but it could be adapted to JS if desired.