### PR TITLE
Rename rake assets:clean to rake assets:clobber to be consistent with sprockets

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -52,7 +52,7 @@ module Propshaft
         end
 
         desc "Remove config.assets.output_path"
-        task clean: :environment do
+        task clobber: :environment do
           Rails.application.assets.processor.clean
         end
 


### PR DESCRIPTION
Following https://github.com/rails/cssbundling-rails/pull/44#issuecomment-975494050

I realised we already have `assets:clean` that removes all files from the output_path, this is actually what `assets:clobber` does in sprockets, as `assets:clean` is more tricky : 

```
rake assets:clean

Only removes old assets (keeps the most recent 3 copies) from public/assets. Useful when doing rolling deploys that may still be serving old assets while the new ones are being compiled.
```

So I suggest we only expose `assets:clobber` to stay consistent as we do not provide a cleaning functionnality (yet?) int he sprockets sense