### PR TITLE
Warn on missing asset in compiler

### DIFF
--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -11,7 +11,7 @@ class Propshaft::Compilers::CssAssetUrls
   end
 
   def compile(logical_path, input)
-    input.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(logical_path.dirname, $1) }
+    input.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(logical_path.dirname, $1), logical_path, $1 }
   end
 
   private
@@ -25,11 +25,12 @@ class Propshaft::Compilers::CssAssetUrls
       end
     end
 
-    def asset_url(resolved_path)
+    def asset_url(resolved_path, logical_path, pattern)
       if asset = assembly.load_path.find(resolved_path)
         %[url("#{assembly.config.prefix}/#{asset.digested_path}")]
       else
-        raise Propshaft::MissingAssetError.new(resolved_path)
+        Propshaft.logger.warn "Removed '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}"
+        %[url("#{pattern}")]
       end
     end
 end

--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -29,7 +29,7 @@ class Propshaft::Compilers::CssAssetUrls
       if asset = assembly.load_path.find(resolved_path)
         %[url("#{assembly.config.prefix}/#{asset.digested_path}")]
       else
-        Propshaft.logger.warn "Removed '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}"
+        Propshaft.logger.warn "Unable to resolve '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}"
         %[url("#{pattern}")]
       end
     end

--- a/test/propshaft/compilers/css_asset_urls_test.rb
+++ b/test/propshaft/compilers/css_asset_urls_test.rb
@@ -91,9 +91,8 @@ class Propshaft::Compilers::CssAssetUrlsTest < ActiveSupport::TestCase
   end
 
   test "missing asset" do
-    assert_raise Propshaft::MissingAssetError do
-      compile_asset_with_content(%({ background: url(missing.jpg); }))
-    end
+    compiled = compile_asset_with_content(%({ background: url("file-not-found.jpg"); }))
+    assert_match /{ background: url\("file-not-found.jpg"\); }/, compiled
   end
 
   private


### PR DESCRIPTION
If an asset cannot be found when processing a CSS file, warn and replace with `url('')` instead of raising.

I did a quick test and the empty url does not seem to generate any extra network requests.