### PR TITLE
Fix Regexp used for CSS comment detection

### DIFF
--- a/lib/propshaft/compilers/source_mapping_urls.rb
+++ b/lib/propshaft/compilers/source_mapping_urls.rb
@@ -3,7 +3,7 @@
 class Propshaft::Compilers::SourceMappingUrls
   attr_reader :assembly
 
-  SOURCE_MAPPING_PATTERN = %r{(//|/\*)# sourceMappingURL=(.*\.map)}
+  SOURCE_MAPPING_PATTERN = %r{^(//|/\*)# sourceMappingURL=(.*\.map)}
 
   def initialize(assembly)
     @assembly = assembly

--- a/lib/propshaft/compilers/source_mapping_urls.rb
+++ b/lib/propshaft/compilers/source_mapping_urls.rb
@@ -3,7 +3,7 @@
 class Propshaft::Compilers::SourceMappingUrls
   attr_reader :assembly
 
-  SOURCE_MAPPING_PATTERN = /(\/\/|\/*)# sourceMappingURL=(.*\.map)/
+  SOURCE_MAPPING_PATTERN = /(\/\/|\/\*)# sourceMappingURL=(.*\.map)/
 
   def initialize(assembly)
     @assembly = assembly

--- a/lib/propshaft/compilers/source_mapping_urls.rb
+++ b/lib/propshaft/compilers/source_mapping_urls.rb
@@ -3,7 +3,7 @@
 class Propshaft::Compilers::SourceMappingUrls
   attr_reader :assembly
 
-  SOURCE_MAPPING_PATTERN = %r{^(//|/\*)# sourceMappingURL=(.*\.map)}
+  SOURCE_MAPPING_PATTERN = %r{^(//|/\*)# sourceMappingURL=(.+\.map)}
 
   def initialize(assembly)
     @assembly = assembly

--- a/lib/propshaft/compilers/source_mapping_urls.rb
+++ b/lib/propshaft/compilers/source_mapping_urls.rb
@@ -3,7 +3,7 @@
 class Propshaft::Compilers::SourceMappingUrls
   attr_reader :assembly
 
-  SOURCE_MAPPING_PATTERN = /(\/\/|\/\*)# sourceMappingURL=(.*\.map)/
+  SOURCE_MAPPING_PATTERN = %r{(//|/\*)# sourceMappingURL=(.*\.map)}
 
   def initialize(assembly)
     @assembly = assembly

--- a/test/fixtures/assets/mapped/sourceMappingURL-not-at-start.css
+++ b/test/fixtures/assets/mapped/sourceMappingURL-not-at-start.css
@@ -1,0 +1,3 @@
+.class {
+  color: green; /*# sourceMappingURL=sourceMappingURL-not-at-start.css.map */
+}

--- a/test/fixtures/assets/mapped/sourceMappingURL-outside-comment.css
+++ b/test/fixtures/assets/mapped/sourceMappingURL-outside-comment.css
@@ -1,0 +1,3 @@
+.class::before {
+  content: "# sourceMappingURL=sourceMappingURL-outside-comment.css.map";
+}

--- a/test/propshaft/compilers/source_mapping_urls_test.rb
+++ b/test/propshaft/compilers/source_mapping_urls_test.rb
@@ -39,4 +39,9 @@ class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
     assert_match %r{sourceMappingURL=sourceMappingURL-outside-comment.css.map},
                  @assembly.compilers.compile(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
   end
+
+  test "sourceMappingURL not at the beginning of the line should be left alone" do
+    assert_match %r{sourceMappingURL=sourceMappingURL-not-at-start.css.map},
+                 @assembly.compilers.compile(find_asset("sourceMappingURL-not-at-start.css", fixture_path: "mapped"))
+  end
 end

--- a/test/propshaft/compilers/source_mapping_urls_test.rb
+++ b/test/propshaft/compilers/source_mapping_urls_test.rb
@@ -29,4 +29,8 @@ class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
     assert_no_match /sourceMappingURL/, @assembly.compilers.compile(find_asset("sourceless.js", fixture_path: "mapped"))
     assert_no_match /sourceMappingURL/, @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
   end
+
+  test "sourceMappingURL outside of a comment should be left alone" do
+    assert_match /sourceMappingURL=sourceMappingURL-outside-comment.css.map/, @assembly.compilers.compile(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
+  end
 end

--- a/test/propshaft/compilers/source_mapping_urls_test.rb
+++ b/test/propshaft/compilers/source_mapping_urls_test.rb
@@ -17,20 +17,26 @@ class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
   end
 
   test "matching source map" do
-    assert_match %r{//# sourceMappingURL=/assets/source.js-[a-z0-9]{40}\.map}, @assembly.compilers.compile(find_asset("source.js", fixture_path: "mapped"))
-    assert_match %r{/\*# sourceMappingURL=/assets/source.css-[a-z0-9]{40}\.map}, @assembly.compilers.compile(find_asset("source.css", fixture_path: "mapped"))
+    assert_match %r{//# sourceMappingURL=/assets/source.js-[a-z0-9]{40}\.map},
+                 @assembly.compilers.compile(find_asset("source.js", fixture_path: "mapped"))
+    assert_match %r{/\*# sourceMappingURL=/assets/source.css-[a-z0-9]{40}\.map},
+                 @assembly.compilers.compile(find_asset("source.css", fixture_path: "mapped"))
   end
 
   test "matching nested source map" do
-    assert_match %r{//# sourceMappingURL=/assets/nested/another-source.js-[a-z0-9]{40}\.map}, @assembly.compilers.compile(find_asset("nested/another-source.js", fixture_path: "mapped"))
+    assert_match %r{//# sourceMappingURL=/assets/nested/another-source.js-[a-z0-9]{40}\.map},
+                 @assembly.compilers.compile(find_asset("nested/another-source.js", fixture_path: "mapped"))
   end
 
   test "missing source map" do
-    assert_no_match %r{sourceMappingURL}, @assembly.compilers.compile(find_asset("sourceless.js", fixture_path: "mapped"))
-    assert_no_match %r{sourceMappingURL}, @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
+    assert_no_match %r{sourceMappingURL},
+                    @assembly.compilers.compile(find_asset("sourceless.js", fixture_path: "mapped"))
+    assert_no_match %r{sourceMappingURL},
+                    @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
   end
 
   test "sourceMappingURL outside of a comment should be left alone" do
-    assert_match %r{sourceMappingURL=sourceMappingURL-outside-comment.css.map}, @assembly.compilers.compile(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
+    assert_match %r{sourceMappingURL=sourceMappingURL-outside-comment.css.map},
+                 @assembly.compilers.compile(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
   end
 end

--- a/test/propshaft/compilers/source_mapping_urls_test.rb
+++ b/test/propshaft/compilers/source_mapping_urls_test.rb
@@ -18,7 +18,7 @@ class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
 
   test "matching source map" do
     assert_match /\/\/# sourceMappingURL=\/assets\/source.js-[a-z0-9]{40}\.map/, @assembly.compilers.compile(find_asset("source.js", fixture_path: "mapped"))
-    assert_match /\/*# sourceMappingURL=\/assets\/source.css-[a-z0-9]{40}\.map/, @assembly.compilers.compile(find_asset("source.css", fixture_path: "mapped"))
+    assert_match /\/\*# sourceMappingURL=\/assets\/source.css-[a-z0-9]{40}\.map/, @assembly.compilers.compile(find_asset("source.css", fixture_path: "mapped"))
   end
 
   test "matching nested source map" do

--- a/test/propshaft/compilers/source_mapping_urls_test.rb
+++ b/test/propshaft/compilers/source_mapping_urls_test.rb
@@ -17,20 +17,20 @@ class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
   end
 
   test "matching source map" do
-    assert_match /\/\/# sourceMappingURL=\/assets\/source.js-[a-z0-9]{40}\.map/, @assembly.compilers.compile(find_asset("source.js", fixture_path: "mapped"))
-    assert_match /\/\*# sourceMappingURL=\/assets\/source.css-[a-z0-9]{40}\.map/, @assembly.compilers.compile(find_asset("source.css", fixture_path: "mapped"))
+    assert_match %r{//# sourceMappingURL=/assets/source.js-[a-z0-9]{40}\.map}, @assembly.compilers.compile(find_asset("source.js", fixture_path: "mapped"))
+    assert_match %r{/\*# sourceMappingURL=/assets/source.css-[a-z0-9]{40}\.map}, @assembly.compilers.compile(find_asset("source.css", fixture_path: "mapped"))
   end
 
   test "matching nested source map" do
-    assert_match /\/\/# sourceMappingURL=\/assets\/nested\/another-source.js-[a-z0-9]{40}\.map/, @assembly.compilers.compile(find_asset("nested/another-source.js", fixture_path: "mapped"))
+    assert_match %r{//# sourceMappingURL=/assets/nested/another-source.js-[a-z0-9]{40}\.map}, @assembly.compilers.compile(find_asset("nested/another-source.js", fixture_path: "mapped"))
   end
 
   test "missing source map" do
-    assert_no_match /sourceMappingURL/, @assembly.compilers.compile(find_asset("sourceless.js", fixture_path: "mapped"))
-    assert_no_match /sourceMappingURL/, @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
+    assert_no_match %r{sourceMappingURL}, @assembly.compilers.compile(find_asset("sourceless.js", fixture_path: "mapped"))
+    assert_no_match %r{sourceMappingURL}, @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
   end
 
   test "sourceMappingURL outside of a comment should be left alone" do
-    assert_match /sourceMappingURL=sourceMappingURL-outside-comment.css.map/, @assembly.compilers.compile(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
+    assert_match %r{sourceMappingURL=sourceMappingURL-outside-comment.css.map}, @assembly.compilers.compile(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
   end
 end


### PR DESCRIPTION
Addresses https://github.com/rails/propshaft/pull/30#discussion_r754539681

Previously the `*` was not escaped in the `SOURCE_MAPPING_PATTERN` Regexp, so it was being interpreted as a "zero or more" quantifier on the previous character (`/`), rather than as a literal `*` as intended. This meant that the Regexp matched the prefix `# sourceMappingURL=` even when it did not appear inside a CSS comment (since zero leading `/` characters is a valid match). This PR fixes the Regexp to properly escape the `*` character, so that it'll only match `/*# sourceMappingURL=`.

The test added in 9dafe50a6aaecc12746a6a81d8f471d786e6301e demonstrates an example where the Regexp was previously working incorrectly (it fails when the `*` is not escaped). Additionally, I changed the Regexp literals to use `%r` syntax so that we don't have to escape the `/` characters to make them easier to follow (1b030f6526c06661015927e49ecef30ace624d63), and I made the pattern a bit stricter so that we can ignore comments that don't appear at the beginning of the line when searching for comments to replace (1dd77990ac285f5b7fb3c95df343fff0f48fe976).