### PR TITLE
Fix assets:clean task

### DIFF
--- a/lib/propshaft/processor.rb
+++ b/lib/propshaft/processor.rb
@@ -21,7 +21,7 @@ class Propshaft::Processor
   end
 
   def clean
-    OutputPath.new(output_path, load_path.manifest).clean(2, 1.hour)
+    Propshaft::OutputPath.new(output_path, load_path.manifest).clean(2, 1.hour)
   end
 
   private


### PR DESCRIPTION
I get this error when running `assets:clean`:

```
rake aborted!
NameError: uninitialized constant Propshaft::Processor::OutputPath
Did you mean?  Propshaft::OutputPath
```

I'm guessing this is because of a quirk in the way Ruby walks namespaces when they're defined inline in the class definition. Fixed by explicitly specifying the namespace.

An alternate fix is to change the class definition to:

```
module Propshaft
  class Processor
    .
    .
    .
  end
end
```

I preferred the former approach.