### PR TITLE
Propshaft::Server#inspect

### DIFF
--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -27,6 +27,10 @@ class Propshaft::Server
     end
   end
 
+  def inspect
+    self.class.inspect
+  end
+
   private
     def extract_path_and_digest(env)
       full_path = Rack::Utils.unescape(env["PATH_INFO"].to_s.sub(/^\//, ""))

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -53,10 +53,6 @@ class Propshaft::ServerTest < ActiveSupport::TestCase
     assert_equal 404, last_response.status
   end
 
-  test "inspect" do
-    assert_equal "Propshaft::Server", @server.inspect
-  end
-
   private
     def default_app
       builder = Rack::Builder.new

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -53,6 +53,10 @@ class Propshaft::ServerTest < ActiveSupport::TestCase
     assert_equal 404, last_response.status
   end
 
+  test "inspect" do
+    assert_equal "Propshaft::Server", @server.inspect
+  end
+
   private
     def default_app
       builder = Rack::Builder.new


### PR DESCRIPTION
The Rails route inspector (typically invoked via `bin/rails routes`)
uses `#inspect` to print the action associated with routes that mount
Rack applications. The output now looks like this:

```
     Prefix Verb URI Pattern        Controller#Action
                 /assets            Propshaft::Server
    widgets GET  /widgets(.:format) widgets#index
```

Resolves #37