### PR TITLE
Add task to reveal the full path of assets

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -44,18 +44,16 @@ class Propshaft::Assembly
       end
   end
 
-  def reveal(type = :logical)
+  def reveal(path_type = :logical_path)
+    path_type = path_type.presence_in(%i[ logical_path path ]) || raise(ArgumentError, "Unknown path_type: #{path_type}")
+    
     load_path.assets.each do |asset|
-      Propshaft.logger.info path_to_reveal(asset, type)
+      Propshaft.logger.info asset.send(path_type)
     end
   end
 
   private
     def manifest_path
       config.output_path.join(Propshaft::Processor::MANIFEST_FILENAME)
-    end
-
-    def path_to_reveal(asset, type)
-      type == :full ? asset.path : asset.logical_path
     end
 end

--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -44,14 +44,18 @@ class Propshaft::Assembly
       end
   end
 
-  def reveal
+  def reveal(type = :logical)
     load_path.assets.each do |asset|
-      Propshaft.logger.info asset.logical_path
+      Propshaft.logger.info path_to_reveal(asset, type)
     end
   end
 
   private
     def manifest_path
       config.output_path.join(Propshaft::Processor::MANIFEST_FILENAME)
+    end
+
+    def path_to_reveal(asset, type)
+      type == :full ? asset.path : asset.logical_path
     end
 end

--- a/lib/propshaft/railties/assets.rake
+++ b/lib/propshaft/railties/assets.rake
@@ -16,13 +16,13 @@ namespace :assets do
 
   desc "Print all the assets available in config.assets.paths"
   task reveal: :environment do
-    Rails.application.assets.reveal
+    Rails.application.assets.reveal(:logical_path)
   end
 
   namespace :reveal do
     desc "Print the full path of assets available in config.assets.paths"
     task full: :environment do
-      Rails.application.assets.reveal(:full)
+      Rails.application.assets.reveal(:path)
     end
   end
 end

--- a/lib/propshaft/railties/assets.rake
+++ b/lib/propshaft/railties/assets.rake
@@ -18,4 +18,11 @@ namespace :assets do
   task reveal: :environment do
     Rails.application.assets.reveal
   end
+
+  namespace :reveal do
+    desc "Print the full path of assets available in config.assets.paths"
+    task full: :environment do
+      Rails.application.assets.reveal(:full)
+    end
+  end
 end


### PR DESCRIPTION
This is useful when migrating from Sprockets, as it helps you figure out where an asset is being sourced from.

I'm not sure if there is a way to test log messages?