### PR TITLE
Add missing `actionpack` dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     propshaft (0.4.2)
+      actionpack (>= 7.0.0.alpha2)
       activesupport (>= 7.0.0.alpha2)
       rack
       railties (>= 7.0.0.alpha2)

--- a/propshaft.gemspec
+++ b/propshaft.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   }
 
   s.required_ruby_version = ">= 2.7.0"
+  s.add_dependency "actionpack", ">= 7.0.0.alpha2"
   s.add_dependency "activesupport", ">= 7.0.0.alpha2"
   s.add_dependency "railties", ">= 7.0.0.alpha2"
   s.add_dependency "rack"


### PR DESCRIPTION
Hey @rafaelfranca 👋 I was actually just about to make a similar change to 8ebe7a58353cd7736412c379358e33cd7118c0df after realizing that propshaft was depending on all of `rails` unnecessarily, but you beat me to it!

However, I think we should have an explicit `actionpack` dependency because we require `action_dispatch/http/mime_type` here:
https://github.com/rails/propshaft/blob/baf693304c642dcdc1f9f60c7d85ddcca236de23/lib/propshaft/asset.rb#L2
which is [part of the `actionpack` gem](https://github.com/rails/rails/blob/ceb4b94baaf17f3a9f4ea795c83ec6c67211f737/actionpack/lib/action_dispatch/http/mime_type.rb).