### PR TITLE
Revert "Remove `Rails::Engine` override to support Rails 4.2"

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -2,6 +2,15 @@ require "rails"
 require "rails/railtie"
 require "active_support/ordered_options"
 
+# FIXME: There's gotta be a better way than this hack?
+class Rails::Engine < Rails::Railtie
+  initializer "propshaft.append_assets_path", group: :all do |app|
+    app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
+    app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
+    app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
+  end
+end
+
 module Propshaft
   class Railtie < ::Rails::Railtie
     config.assets = ActiveSupport::OrderedOptions.new
@@ -33,12 +42,6 @@ module Propshaft
           before_action { Rails.application.assets.load_path.cache_sweeper.execute_if_updated }
         end
       end
-    end
-
-    initializer "propshaft.append_assets_path" do |app|
-      app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
-      app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
-      app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
     end
 
     initializer "propshaft.logger" do


### PR DESCRIPTION
Fixes https://github.com/rails/propshaft/issues/41

This reverts commit 66ce0f889377b81a28b1dd1fbe245868a047d46f.

That change introduced this failure upon application initialization:
```
/home/runner/work/propshaft/propshaft/lib/propshaft/railtie.rb:39:in `block in <class:Railtie>': undefined local variable or method `paths' for #<Propshaft::Railtie:0x0000563194f5cf28> (NameError)
Did you mean?  Pathname
	from /home/runner/work/propshaft/propshaft/vendor/bundle/ruby/2.7.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:32:in `instance_exec'
	from /home/runner/work/propshaft/propshaft/vendor/bundle/ruby/2.7.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:32:in `run'
	from /home/runner/work/propshaft/propshaft/vendor/bundle/ruby/2.7.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:347:in `each'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:347:in `call'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	from /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	from /home/runner/work/propshaft/propshaft/vendor/bundle/ruby/2.7.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:60:in `run_initializers'
	from /home/runner/work/propshaft/propshaft/vendor/bundle/ruby/2.7.0/gems/railties-7.0.0.alpha2/lib/rails/application.rb:369:in `initialize!'
	from /home/runner/work/propshaft/propshaft/test/dummy/config/environment.rb:5:in `<top (required)>'
```
https://github.com/rails/propshaft/runs/4414708235?check_suite_focus=true#step:4:4

Let's revert it until we find an alternative that works.