### PR TITLE
Remove note about pending rails PR from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ So that's what Propshaft doesn't do. Here's what it does provide:
 
 ## Installation
 
-With Rails 7+, you can start a new application with propshaft using `rails new myapp -a propshaft` (pending the merge of [rails/rails#43261](https://github.com/rails/rails/pull/43261)).
+With Rails 7+, you can start a new application with propshaft using `rails new myapp -a propshaft`.
 
 
 ## Usage


### PR DESCRIPTION
[Rails 7.0.0.rc1 has been released](https://weblog.rubyonrails.org/2021/12/6/Rails-7-0-rc-1-released) which includes https://github.com/rails/rails/pull/43261. Thus, `rails new myapp -a propshaft` works now, so we can remove this caveat.