### PR TITLE
Swallow fingerprint from css asset urls

### DIFF
--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -3,7 +3,7 @@
 class Propshaft::Compilers::CssAssetUrls
   attr_reader :assembly
 
-  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|data|http))([^"'\s)]+)\s*["']?\)/
+  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|data|http))([^"'\s?#)]+)([#?][^"']+)?\s*["']?\)/
 
   def initialize(assembly)
     @assembly = assembly

--- a/test/propshaft/compilers/css_asset_urls_test.rb
+++ b/test/propshaft/compilers/css_asset_urls_test.rb
@@ -90,6 +90,16 @@ class Propshaft::Compilers::CssAssetUrlsTest < ActiveSupport::TestCase
     assert_match "{ background: url(#IDofSVGpath); }", compiled
   end
 
+  test "fingerprint" do
+    compiled = compile_asset_with_content(%({ background: url('/file.jpg?30af91bf14e37666a085fb8a161ff36d'); }))
+    assert_match(/{ background: url\("\/assets\/file-[a-z0-9]{40}.jpg"\); }/, compiled)
+  end
+
+  test "hash symbol" do
+    compiled = compile_asset_with_content(%({ background: url('/file.jpg#fontawesome'); }))
+    assert_match(/{ background: url\("\/assets\/file-[a-z0-9]{40}.jpg"\); }/, compiled)
+  end
+
   test "missing asset" do
     compiled = compile_asset_with_content(%({ background: url("file-not-found.jpg"); }))
     assert_match(/{ background: url\("file-not-found.jpg"\); }/, compiled)


### PR DESCRIPTION
Partly closes #47.

This PR makes the CSS compiler regex swallow the fingerprint after `?` in asset urls. 

Benchmark indicates a 3% slowdown.