### PR TITLE
Add support for SRI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
+      actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -20,6 +20,10 @@ class Propshaft::Asset
     content.size
   end
 
+  def integrity
+    @integrity ||= "sha384-#{[Digest::SHA384.digest(content)].pack('m0')}"
+  end
+
   def digest
     @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")
   end

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -1,7 +1,31 @@
 module Propshaft
+  include ActionView::Helpers::AssetTagHelper
+
   module Helper
     def compute_asset_path(path, options = {})
       Rails.application.assets.resolver.resolve(path) || raise(MissingAssetError.new(path))
     end
+
+    def javascript_include_tag(*sources)
+      options = sources.extract_options!.stringify_keys
+
+      sources.map { |source|
+        options = options.merge("integrity" => asset_integrity(source, options))
+        super source, options
+      }.join("\n").html_safe
+    end
+
+    protected
+      def asset_integrity(path, options)
+        if options["integrity"] && secure_subresource_integrity_context?
+          Rails.application.assets.resolver.integrity("#{path}.js")
+        end
+      end
+
+      # Only serve integrity metadata for HTTPS requests:
+      #   http://www.w3.org/TR/SRI/#non-secure-contexts-remain-non-secure
+      def secure_subresource_integrity_context?
+        respond_to?(:request) && self.request && (self.request.local? || self.request.ssl?)
+      end
   end
 end

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -23,7 +23,10 @@ class Propshaft::LoadPath
   def manifest
     Hash.new.tap do |manifest|
       assets.each do |asset|
-        manifest[asset.logical_path.to_s] = asset.digested_path.to_s
+        manifest[asset.logical_path.to_s] = {
+          "digested_path" => asset.digested_path.to_s,
+          "integrity" => asset.integrity
+        }
       end
     end
   end

--- a/lib/propshaft/resolver/dynamic.rb
+++ b/lib/propshaft/resolver/dynamic.rb
@@ -17,5 +17,13 @@ module Propshaft::Resolver
         asset.content
       end
     end
+
+    def integrity(logical_path)
+      if asset = load_path.find(logical_path)
+        asset.integrity
+      else
+        raise Propshaft::MissingAssetError.new(logical_path)
+      end
+    end
   end
 end

--- a/lib/propshaft/resolver/static.rb
+++ b/lib/propshaft/resolver/static.rb
@@ -7,14 +7,22 @@ module Propshaft::Resolver
     end
 
     def resolve(logical_path)
-      if asset_path = parsed_manifest[logical_path]
-        File.join prefix, asset_path
+      if asset = parsed_manifest[logical_path]
+        File.join prefix, asset["digested_path"]
       end
     end
 
     def read(logical_path)
-      if asset_path = parsed_manifest[logical_path]
-        manifest_path.dirname.join(asset_path).read
+      if asset = parsed_manifest[logical_path]
+        manifest_path.dirname.join(asset["digested_path"]).read
+      end
+    end
+
+    def integrity(logical_path)
+      if asset = parsed_manifest[logical_path]
+        asset["integrity"]
+      else
+        raise Propshaft::MissingAssetError.new(logical_path)
       end
     end
 

--- a/propshaft.gemspec
+++ b/propshaft.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   }
 
   s.required_ruby_version = ">= 2.7.0"
+  s.add_dependency "actionview", ">= 7.0.0"
   s.add_dependency "actionpack", ">= 7.0.0"
   s.add_dependency "activesupport", ">= 7.0.0"
   s.add_dependency "railties", ">= 7.0.0"

--- a/test/dummy/app/controllers/sample_controller.rb
+++ b/test/dummy/app/controllers/sample_controller.rb
@@ -4,4 +4,7 @@ class SampleController < ApplicationController
 
   def load_nonexistent_assets
   end
+
+  def load_assets_with_integrity
+  end
 end

--- a/test/dummy/app/views/sample/load_assets_with_integrity.html.erb
+++ b/test/dummy/app/views/sample/load_assets_with_integrity.html.erb
@@ -1,0 +1,6 @@
+<%= stylesheet_link_tag "hello_world" %>
+
+<h1>Sample#load_real_assets</h1>
+<p>Find me in app/views/sample/load_real_assets.html.erb</p>
+
+<%= javascript_include_tag "hello_world", integrity: true %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get 'sample/load_real_assets'
   get 'sample/load_nonexistent_assets'
+  get 'sample/load_assets_with_integrity'
 end

--- a/test/fixtures/output/.manifest.json
+++ b/test/fixtures/output/.manifest.json
@@ -1,1 +1,4 @@
-{ "one.txt": "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt" }
+{ "one.txt": {
+  "digested_path": "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt",
+  "integrity": "sha384-LdS8l2QTAF8bD8WPb8QSQv0skTWHhmcnS2XU5LBkVQneGzqIqnDRskQtJvi7ADMe"
+} }

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -21,6 +21,10 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     assert_equal "f2e1ec14d6856e1958083094170ca6119c529a73", find_asset("one.txt").digest
   end
 
+  test "integrity" do
+    assert_equal "sha384-LdS8l2QTAF8bD8WPb8QSQv0skTWHhmcnS2XU5LBkVQneGzqIqnDRskQtJvi7ADMe", find_asset("one.txt").integrity
+  end
+
   test "fresh" do
     assert find_asset("one.txt").fresh?("f2e1ec14d6856e1958083094170ca6119c529a73")
     assert_not find_asset("one.txt").fresh?("e206c34fe404c8e2f25d60dd8303f61c02b8d381")

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -38,16 +38,16 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
 
   test "manifest" do
     @load_path.manifest.tap do |manifest|
-      assert_equal "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt", manifest["one.txt"]
-      assert_equal "nested/three-6c2b86a0206381310375abdd9980863c2ea7b2c3.txt", manifest["nested/three.txt"]
+      assert_equal "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt", manifest["one.txt"]["digested_path"]
+      assert_equal "nested/three-6c2b86a0206381310375abdd9980863c2ea7b2c3.txt", manifest["nested/three.txt"]["digested_path"]
     end
   end
 
   test "manifest with version" do
     @load_path = Propshaft::LoadPath.new(@load_path.paths, version: "1")
     @load_path.manifest.tap do |manifest|
-      assert_equal "one-c9373b685d5a63e4a1de7c6836a73239df552e2b.txt", manifest["one.txt"]
-      assert_equal "nested/three-a41a5d38da5afe428eca74b243f50405f28a6b54.txt", manifest["nested/three.txt"]
+      assert_equal "one-c9373b685d5a63e4a1de7c6836a73239df552e2b.txt", manifest["one.txt"]["digested_path"]
+      assert_equal "nested/three-a41a5d38da5afe428eca74b243f50405f28a6b54.txt", manifest["nested/three.txt"]["digested_path"]
     end
   end
 

--- a/test/propshaft/output_path_test.rb
+++ b/test/propshaft/output_path_test.rb
@@ -7,9 +7,9 @@ require "propshaft/output_path"
 class Propshaft::OutputPathTest < ActiveSupport::TestCase
   setup do
     @manifest    = {
-      ".manifest.json": ".manifest.json",
-      "one.txt": "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt"
-    }.stringify_keys
+      ".manifest.json" => ".manifest.json",
+      "one.txt" => "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt"
+    }
     @output_path = Propshaft::OutputPath.new(Pathname.new("#{__dir__}/../fixtures/output"), @manifest)
   end
 

--- a/test/propshaft/processor_test.rb
+++ b/test/propshaft/processor_test.rb
@@ -16,8 +16,9 @@ class Propshaft::ProcessorTest < ActiveSupport::TestCase
 
   test "manifest is written" do
     processed do |processor|
-      assert_equal "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt",
-         JSON.parse(processor.output_path.join(".manifest.json").read)["one.txt"]
+      asset = JSON.parse(processor.output_path.join(".manifest.json").read)["one.txt"]
+      assert_equal "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt", asset["digested_path"]
+      assert_equal "sha384-LdS8l2QTAF8bD8WPb8QSQv0skTWHhmcnS2XU5LBkVQneGzqIqnDRskQtJvi7ADMe", asset["integrity"]
     end
   end
 

--- a/test/propshaft/resolver/dynamic_test.rb
+++ b/test/propshaft/resolver/dynamic_test.rb
@@ -19,4 +19,15 @@ class Propshaft::Resolver::DynamicTest < ActiveSupport::TestCase
   test "resolving missing asset returns nil" do
     assert_nil @resolver.resolve("nowhere.txt")
   end
+
+  test "integrity of an existing asset returns value" do
+    assert_equal "sha384-LdS8l2QTAF8bD8WPb8QSQv0skTWHhmcnS2XU5LBkVQneGzqIqnDRskQtJvi7ADMe",
+      @resolver.integrity("one.txt")
+  end
+
+  test "integrity of missing asset raises a custom error" do
+    assert_raise Propshaft::MissingAssetError do
+      assert_nil @resolver.integrity("nowhere.txt")
+    end
+  end
 end

--- a/test/propshaft/resolver/static_test.rb
+++ b/test/propshaft/resolver/static_test.rb
@@ -22,4 +22,15 @@ class Propshaft::Resolver::StaticTest < ActiveSupport::TestCase
   test "resolving missing asset returns nil" do
     assert_nil @resolver.resolve("nowhere.txt")
   end
+
+  test "integrity of an existing asset returns value" do
+    assert_equal "sha384-LdS8l2QTAF8bD8WPb8QSQv0skTWHhmcnS2XU5LBkVQneGzqIqnDRskQtJvi7ADMe",
+                 @resolver.integrity("one.txt")
+  end
+
+  test "integrity of missing asset raises a custom error" do
+    assert_raise Propshaft::MissingAssetError do
+      assert_nil @resolver.integrity("nowhere.txt")
+    end
+  end
 end

--- a/test/propshaft_integration_test.rb
+++ b/test/propshaft_integration_test.rb
@@ -14,4 +14,10 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
     end
     assert_equal "The asset 'nonexistent.css' was not found in the load path.", exception.message
   end
+
+  test "should be able to resolve javascript assets with integrity" do
+    get sample_load_assets_with_integrity_url
+    assert_response :success
+    assert_select 'script[src="/assets/hello_world-00956908343eaa8d47963b94a7e47ae2919a79cd.js"][integrity="sha384-BIr0kyMRq2sfytK/T0XlGjfav9ZZrWkSBC2yHVunCchnkpP83H28/UtHw+m9iNHO"]'
+  end
 end


### PR DESCRIPTION
Adds support for Subresource Integrity through the `integrity` option in `javascript_include_tag`
https://www.w3.org/TR/SRI

Closes #56 