### PR TITLE
Include config.assets.version in digests

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -15,7 +15,7 @@ class Propshaft::Assembly
   end
 
   def load_path
-    @load_path ||= Propshaft::LoadPath.new(config.paths)
+    @load_path ||= Propshaft::LoadPath.new(config.paths, version: config.version)
   end
 
   def resolver

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -2,10 +2,10 @@ require "digest/sha1"
 require "action_dispatch/http/mime_type"
 
 class Propshaft::Asset
-  attr_reader :path, :logical_path
+  attr_reader :path, :logical_path, :version
 
-  def initialize(path, logical_path:)
-    @path, @logical_path = path, Pathname.new(logical_path)
+  def initialize(path, logical_path:, version: nil)
+    @path, @logical_path, @version = path, Pathname.new(logical_path), version
   end
 
   def content
@@ -21,7 +21,7 @@ class Propshaft::Asset
   end
 
   def digest
-    @digest ||= Digest::SHA1.hexdigest(content)
+    @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")
   end
 
   def digested_path

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -1,10 +1,11 @@
 require "propshaft/asset"
 
 class Propshaft::LoadPath
-  attr_reader :paths
+  attr_reader :paths, :version
 
-  def initialize(paths = [])
-    @paths = Array(paths).collect { |path| Pathname.new(path) }
+  def initialize(paths = [], version: nil)
+    @paths   = Array(paths).collect { |path| Pathname.new(path) }
+    @version = version
   end
 
   def find(asset_name)
@@ -47,7 +48,7 @@ class Propshaft::LoadPath
         paths.each do |path|
           without_dotfiles(all_files_from_tree(path)).each do |file|
             logical_path = file.relative_path_from(path)
-            mapped[logical_path.to_s] ||= Propshaft::Asset.new(file, logical_path: logical_path)
+            mapped[logical_path.to_s] ||= Propshaft::Asset.new(file, logical_path: logical_path, version: version)
           end if path.exist?
         end
       end

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -6,6 +6,7 @@ module Propshaft
     config.assets = ActiveSupport::OrderedOptions.new
     config.assets.paths          = []
     config.assets.excluded_paths = []
+    config.assets.version        = "1"
     config.assets.prefix         = "/assets"
     config.assets.compilers      = [
       [ "text/css", Propshaft::Compilers::CssAssetUrls ],

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -43,6 +43,14 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     end
   end
 
+  test "manifest with version" do
+    @load_path = Propshaft::LoadPath.new(@load_path.paths, version: "1")
+    @load_path.manifest.tap do |manifest|
+      assert_equal "one-c9373b685d5a63e4a1de7c6836a73239df552e2b.txt", manifest["one.txt"]
+      assert_equal "nested/three-a41a5d38da5afe428eca74b243f50405f28a6b54.txt", manifest["nested/three.txt"]
+    end
+  end
+
   test "missing load path directory" do
     assert_nil Propshaft::LoadPath.new(Pathname.new("#{__dir__}/../fixtures/assets/nowhere")).find("missing")
   end


### PR DESCRIPTION
In case we change any of the compilers or other factors that affect output.