### PR TITLE
Static Resolver is Used in Development Mode

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -178,3 +178,7 @@ It's a common pattern in apps to inline small SVG files and low resolution versi
 ```ruby
 Rails.application.assets.load_path.find('logo.svg').content
 ```
+
+**Precompilation in development**
+
+Propshaft is using dynamic assets resolver in development mode. However, when you run `assets:precompile` locally - it's then switching to static assets resolver. Your changes to assets will not be anymore observed and you'd have to precompile assets each time. This is different to Sprockets.


### PR DESCRIPTION
If you run `assets:precompile` in development mode and forget to clean assets (so `public/assets/.manifest.json` exists) - Propshaft will then use static resolve to serve assets. When you forget that you've done this - you might be wondering why Rails is serving old version of assets.

I was thinking about adding code to `Propshaft::Assembly#resolver` method to check if `config.assets.compile` is set. Something like this

```
def resolver
  @resolver ||= if manifest_path.exist? && !config.assets[:compile]
    Propshaft::Resolver::Static.new manifest_path: manifest_path, prefix: config.prefix
  else
    Propshaft::Resolver::Dynamic.new load_path: load_path, prefix: config.prefix
  end
end
```

but then I saw this code in `railtie.rb`

```
# Compatibility shiming (need to provide log warnings when used)
config.assets.compile        = nil
```

That suggests that this parameter will be dropped in future. So I've decided to update documentation as that's a change from Sprockets.