### PR TITLE
Deduplicate paths

### DIFF
--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -4,7 +4,7 @@ class Propshaft::LoadPath
   attr_reader :paths, :version
 
   def initialize(paths = [], version: nil)
-    @paths   = Array(paths).collect { |path| Pathname.new(path) }
+    @paths = dedup(paths)
     @version = version
   end
 
@@ -64,5 +64,13 @@ class Propshaft::LoadPath
 
     def clear_cache
       @cached_assets_by_path = nil
+    end
+
+    def dedup(paths)
+      [].tap do |deduped|
+        Array(paths).sort.each do |path|
+          deduped << Pathname.new(path) if deduped.blank? || !path.to_s.start_with?(deduped.last.to_s)
+        end
+      end
     end
 end

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -55,6 +55,21 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     assert_nil Propshaft::LoadPath.new(Pathname.new("#{__dir__}/../fixtures/assets/nowhere")).find("missing")
   end
 
+  test "deduplicate paths" do
+    load_path = Propshaft::LoadPath.new [
+      "app/assets/stylesheets",
+      "app/assets/images",
+      "app/assets",
+      "app/javascript",
+      "app/javascript/packs"
+    ]
+
+    paths = load_path.paths
+    assert_equal 2, paths.count
+    assert_equal Pathname.new("app/assets"), paths.first
+    assert_equal Pathname.new("app/javascript"), paths.last
+  end
+
   private
     def find_asset(logical_path)
       Propshaft::Asset.new(


### PR DESCRIPTION
Only keep the shortest ancestor of every path in the load path.

Input:
```text
app/assets/stylesheets
app/assets/images
app/assets
app/javascript
app/javascript/packs
```

Output:
```text
app/assets
app/javascript
```