### PR TITLE
Fix string comarison with pathname error

### DIFF
--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -68,7 +68,7 @@ class Propshaft::LoadPath
 
     def dedup(paths)
       [].tap do |deduped|
-        Array(paths).sort.each do |path|
+        Array(paths.map(&:to_s)).sort.each do |path|
           deduped << Pathname.new(path) if deduped.blank? || !path.to_s.start_with?(deduped.last.to_s)
         end
       end

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -68,8 +68,8 @@ class Propshaft::LoadPath
 
     def dedup(paths)
       [].tap do |deduped|
-        Array(paths.map(&:to_s)).sort.each do |path|
-          deduped << Pathname.new(path) if deduped.blank? || !path.to_s.start_with?(deduped.last.to_s)
+        Array(paths).map(&:to_s).sort.each do |path|
+          deduped << Pathname.new(path) if deduped.blank? || !path.start_with?(deduped.last.to_s)
         end
       end
     end

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -5,7 +5,7 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
   setup do
     @load_path = Propshaft::LoadPath.new [
       Pathname.new("#{__dir__}/../fixtures/assets/first_path"),
-      Pathname.new("#{__dir__}/../fixtures/assets/second_path")
+      Pathname.new("#{__dir__}/../fixtures/assets/second_path").to_s
     ]
   end
 


### PR DESCRIPTION
The latest update broke `rake assets:precompile` when a Pathname exists in the paths array

```
ArgumentError: comparison of String with Pathname failed
/Users/fiyah/workspace/ruby/propshaft/lib/propshaft/load_path.rb:72:in `sort'
/Users/fiyah/workspace/ruby/propshaft/lib/propshaft/load_path.rb:72:in `block in dedup'
```