### PR TITLE
Resolve already digested assets using their undigested path

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -4,6 +4,8 @@ require "action_dispatch/http/mime_type"
 class Propshaft::Asset
   attr_reader :path, :logical_path, :version
 
+  DIGESTED_NAME_PATTERN = /-([0-9a-zA-Z]{7,128})\.digested/
+
   def initialize(path, logical_path:, version: nil)
     @path, @logical_path, @version = path, Pathname.new(logical_path), version
   end
@@ -32,6 +34,10 @@ class Propshaft::Asset
     end
   end
 
+  def undigested_path
+    logical_path.sub(DIGESTED_NAME_PATTERN, "")
+  end
+
   def fresh?(digest)
     self.digest == digest || already_digested?
   end
@@ -42,6 +48,6 @@ class Propshaft::Asset
 
   private
     def already_digested?
-      logical_path.to_s =~ /-([0-9a-zA-Z]{7,128})\.digested/
+      logical_path.to_s =~ DIGESTED_NAME_PATTERN
     end
 end

--- a/test/dummy/app/assets/javascripts/already_digested-50f7d266afaecd96b52d41cbfaa49d03444bd845.digested.js
+++ b/test/dummy/app/assets/javascripts/already_digested-50f7d266afaecd96b52d41cbfaa49d03444bd845.digested.js
@@ -1,0 +1,1 @@
+console.log("Already digested js file!")

--- a/test/dummy/app/assets/stylesheets/already_digested-7d38ef727d2fe5e6cce3ca288b5668f38eedaee9.digested.css
+++ b/test/dummy/app/assets/stylesheets/already_digested-7d38ef727d2fe5e6cce3ca288b5668f38eedaee9.digested.css
@@ -1,0 +1,3 @@
+h1:after {
+  content: " Already digested assets!";
+}

--- a/test/dummy/app/controllers/sample_controller.rb
+++ b/test/dummy/app/controllers/sample_controller.rb
@@ -4,4 +4,7 @@ class SampleController < ApplicationController
 
   def load_nonexistent_assets
   end
+
+  def load_already_digested_assets
+  end
 end

--- a/test/dummy/app/views/sample/load_already_digested_assets.html.erb
+++ b/test/dummy/app/views/sample/load_already_digested_assets.html.erb
@@ -1,0 +1,6 @@
+<%= stylesheet_link_tag "already_digested" %>
+
+<h1>Sample#load_already_digested_assets</h1>
+<p>Find me in app/views/sample/load_already_digested_assets.html.erb</p>
+
+<%= javascript_include_tag "already_digested" %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get 'sample/load_real_assets'
   get 'sample/load_nonexistent_assets'
+  get 'sample/load_already_digested_assets'
 end

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -42,6 +42,19 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
       find_asset("file-not.digested.css").digested_path.to_s
   end
 
+  test "undigested path" do
+    assert_equal "one.txt", find_asset("one.txt").undigested_path.to_s
+
+    assert_equal "file-already.css",
+      find_asset("file-already-abcdefVWXYZ0123456789.digested.css").undigested_path.to_s
+
+    assert_equal "file-already.debug.css",
+      find_asset("file-already-abcdefVWXYZ0123456789.digested.debug.css").undigested_path.to_s
+
+    assert_equal "file-not.digested-e206c34fe404c8e2f25d60dd8303f61c02b8d381.css",
+      find_asset("file-not.digested-e206c34fe404c8e2f25d60dd8303f61c02b8d381.css").undigested_path.to_s
+  end
+
   test "value object equality" do
     assert_equal find_asset("one.txt"), find_asset("one.txt")
   end

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -40,6 +40,8 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     @load_path.manifest.tap do |manifest|
       assert_equal "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt", manifest["one.txt"]
       assert_equal "nested/three-6c2b86a0206381310375abdd9980863c2ea7b2c3.txt", manifest["nested/three.txt"]
+      assert_equal "file-already-abcdefVWXYZ0123456789.digested.css", manifest["file-already-abcdefVWXYZ0123456789.digested.css"]
+      assert_equal "file-already-abcdefVWXYZ0123456789.digested.css", manifest["file-already.css"]
     end
   end
 
@@ -48,6 +50,8 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     @load_path.manifest.tap do |manifest|
       assert_equal "one-c9373b685d5a63e4a1de7c6836a73239df552e2b.txt", manifest["one.txt"]
       assert_equal "nested/three-a41a5d38da5afe428eca74b243f50405f28a6b54.txt", manifest["nested/three.txt"]
+      assert_equal "file-already-abcdefVWXYZ0123456789.digested.css", manifest["file-already-abcdefVWXYZ0123456789.digested.css"]
+      assert_equal "file-already-abcdefVWXYZ0123456789.digested.css", manifest["file-already.css"]
     end
   end
 

--- a/test/propshaft_integration_test.rb
+++ b/test/propshaft_integration_test.rb
@@ -14,4 +14,11 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
     end
     assert_equal "The asset 'nonexistent.css' was not found in the load path.", exception.message
   end
+
+  test "should be able to resolve already digested assets" do
+    get sample_load_already_digested_assets_url
+    assert_response :success
+    assert_select 'link[href="/assets/already_digested-7d38ef727d2fe5e6cce3ca288b5668f38eedaee9.digested.css"]'
+    assert_select 'script[src="/assets/already_digested-50f7d266afaecd96b52d41cbfaa49d03444bd845.digested.js"]'
+  end
 end


### PR DESCRIPTION
This is especially useful when assets are already being digested by a module bundler (webpack, etc.), but we want to resolve them based on their base name.