### PR TITLE
Preserve asset paths order when deduping

### DIFF
--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -4,7 +4,7 @@ class Propshaft::LoadPath
   attr_reader :paths, :version
 
   def initialize(paths = [], version: nil)
-    @paths = dedup(paths)
+    @paths   = dedup(paths)
     @version = version
   end
 
@@ -67,10 +67,11 @@ class Propshaft::LoadPath
     end
 
     def dedup(paths)
-      [].tap do |deduped|
-        Array(paths).map(&:to_s).sort.each do |path|
-          deduped << Pathname.new(path) if deduped.blank? || !path.start_with?(deduped.last.to_s)
-        end
+      paths   = Array(paths).map { |path| Pathname.new(path) }
+      deduped = [].tap do |deduped|
+        paths.sort.each { |path| deduped << path if deduped.blank? || !path.to_s.start_with?(deduped.last.to_s) }
       end
+
+      paths & deduped
     end
 end

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -57,17 +57,17 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
 
   test "deduplicate paths" do
     load_path = Propshaft::LoadPath.new [
+      "app/javascript",
+      "app/javascript/packs",
       "app/assets/stylesheets",
       "app/assets/images",
-      "app/assets",
-      "app/javascript",
-      "app/javascript/packs"
+      "app/assets"
     ]
 
     paths = load_path.paths
     assert_equal 2, paths.count
-    assert_equal Pathname.new("app/assets"), paths.first
-    assert_equal Pathname.new("app/javascript"), paths.last
+    assert_equal Pathname.new("app/javascript"), paths.first
+    assert_equal Pathname.new("app/assets"), paths.last
   end
 
   private


### PR DESCRIPTION
Preserve the order of asset paths when deduplicating. 

This closes #74, but it's only treating the symptoms, without actually fixing the cause (duplicate logical paths).

@miharekar I've tested this in your project, and it seems to work, but do you mind take another look to ensure I did not miss something?