### PR TITLE
Instruct removing Sprockets from Gemfile

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,7 +132,7 @@ Sass might raise deprecation warnings depending on what features you are using (
 
 Start by following these steps:
 
-1. Remove `sprockets` and `sass-rails` from the gemfile and add `propshaft`;
+1. Remove `sprockets`, `sprockets-rails`, and `sass-rails` from the gemfile and add `propshaft`;
 2. Run `./bin/bundle install`;
 3. Open `config/application.rb` and remove `config.assets.paths << Rails.root.join('app','assets')`;
 4. Remove `asset/config/manifest.js`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,7 +132,7 @@ Sass might raise deprecation warnings depending on what features you are using (
 
 Start by following these steps:
 
-1. Replace `sass-rails` with `propshaft`;
+1. Remove `sprockets` and `sass-rails` from the gemfile and add `propshaft`;
 2. Run `./bin/bundle install`;
 3. Open `config/application.rb` and remove `config.assets.paths << Rails.root.join('app','assets')`;
 4. Remove `asset/config/manifest.js`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,7 +132,7 @@ Sass might raise deprecation warnings depending on what features you are using (
 
 Start by following these steps:
 
-1. Remove `sprockets`, `sprockets-rails`, and `sass-rails` from the gemfile and add `propshaft`;
+1. Remove `sprockets`, `sprockets-rails`, and `sass-rails` from the Gemfile and add `propshaft`;
 2. Run `./bin/bundle install`;
 3. Open `config/application.rb` and remove `config.assets.paths << Rails.root.join('app','assets')`;
 4. Remove `asset/config/manifest.js`.


### PR DESCRIPTION
I suppose the upgrade guide introduced in #35 should instruct to remove Sprockets from the Gemfile?

Section 3 point 4 instructs to remove `app/assets/config/manifest.js`, which yields `Sprockets::Railtie::ManifestNeededError` when Sprockets is still present.