### PR TITLE
Improve css compiler

### DIFF
--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -3,14 +3,14 @@
 class Propshaft::Compilers::CssAssetUrls
   attr_reader :assembly
 
-  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|data|http|\/\/))([^"'\s?#)]+)([#?][^"']+)?\s*["']?\)/
+  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|data|http|\/\/))([^"'\s?#)]+)([#?][^"')]+)?\s*["']?\)/
 
   def initialize(assembly)
     @assembly = assembly
   end
 
   def compile(logical_path, input)
-    input.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(logical_path.dirname, $1), logical_path, $1 }
+    input.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(logical_path.dirname, $1), logical_path, $2, $1 }
   end
 
   private
@@ -24,9 +24,9 @@ class Propshaft::Compilers::CssAssetUrls
       end
     end
 
-    def asset_url(resolved_path, logical_path, pattern)
+    def asset_url(resolved_path, logical_path, fingerprint, pattern)
       if asset = assembly.load_path.find(resolved_path)
-        %[url("#{assembly.config.prefix}/#{asset.digested_path}")]
+        %[url("#{assembly.config.prefix}/#{asset.digested_path}#{fingerprint}")]
       else
         Propshaft.logger.warn "Unable to resolve '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}"
         %[url("#{pattern}")]

--- a/test/propshaft/compilers/css_asset_urls_test.rb
+++ b/test/propshaft/compilers/css_asset_urls_test.rb
@@ -97,12 +97,17 @@ class Propshaft::Compilers::CssAssetUrlsTest < ActiveSupport::TestCase
 
   test "fingerprint" do
     compiled = compile_asset_with_content(%({ background: url('/file.jpg?30af91bf14e37666a085fb8a161ff36d'); }))
-    assert_match(/{ background: url\("\/assets\/file-[a-z0-9]{40}.jpg"\); }/, compiled)
+    assert_match(/{ background: url\("\/assets\/file-[a-z0-9]{40}.jpg\?30af91bf14e37666a085fb8a161ff36d"\); }/, compiled)
   end
 
-  test "hash symbol" do
-    compiled = compile_asset_with_content(%({ background: url('/file.jpg#fontawesome'); }))
-    assert_match(/{ background: url\("\/assets\/file-[a-z0-9]{40}.jpg"\); }/, compiled)
+  test "svg anchor" do
+    compiled = compile_asset_with_content(%({ content: url(file.svg#rails); }))
+    assert_match(/{ content: url\("\/assets\/foobar\/source\/file-[a-z0-9]{40}.svg#rails"\); }/, compiled)
+  end
+
+  test "non greedy anchors" do
+    compiled = compile_asset_with_content(%({ content: url(file.svg#demo) url(file.svg#demo); }))
+    assert_match(/{ content: url\("\/assets\/foobar\/source\/file-[a-z0-9]{40}.svg#demo"\) url\("\/assets\/foobar\/source\/file-[a-z0-9]{40}.svg#demo"\); }/, compiled)
   end
 
   test "missing asset" do


### PR DESCRIPTION
Improves on #50 
Closes #78

Instead of stripping everything after the file extension, let's preserve it.
Also, make the regex less greedy.

@flipsasser could you confirm if this works for both your bugs?
@kevynlebouille or @HLFH would you mind checking if your uses cases are still working correctly?