### PR TITLE
Identify relative protocol asset URLs

### DIFF
--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -3,7 +3,7 @@
 class Propshaft::Compilers::CssAssetUrls
   attr_reader :assembly
 
-  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|data|http))([^"'\s?#)]+)([#?][^"']+)?\s*["']?\)/
+  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|data|http|\/\/))([^"'\s?#)]+)([#?][^"']+)?\s*["']?\)/
 
   def initialize(assembly)
     @assembly = assembly

--- a/test/propshaft/compilers/css_asset_urls_test.rb
+++ b/test/propshaft/compilers/css_asset_urls_test.rb
@@ -80,6 +80,11 @@ class Propshaft::Compilers::CssAssetUrlsTest < ActiveSupport::TestCase
     assert_match "{ background: url('https://rubyonrails.org/images/rails-logo.svg'); }", compiled
   end
 
+  test "relative protocol url" do
+    compiled = compile_asset_with_content(%({ background: url('//rubyonrails.org/images/rails-logo.svg'); }))
+    assert_match "{ background: url('//rubyonrails.org/images/rails-logo.svg'); }", compiled
+  end
+
   test "data" do
     compiled = compile_asset_with_content(%({ background: url(data:image/png;base64,iRxVB0); }))
     assert_match "{ background: url(data:image/png;base64,iRxVB0); }", compiled


### PR DESCRIPTION
Hello. Propshaft does not appear to be detecting URLs using the double-slash relative protocol, eg:

```
@font-face { font-family: Inter; src:url("//fonts.gstatic.com/s/inter/abc.eot") } # abridged
```

This leads them to be processed as local assets, with the subsequent warning:

```
Unable to resolve '//fonts.gstatic.com/s/inter/abc.eot' for missing asset '/fonts.gstatic.com/s/inter/s/inter/abc.eot' in application.css
```

This PR adds "//" to the URL regex's negative lookahead.

Thanks!