### PR TITLE
Add support to oj gem

### DIFF
--- a/lib/propshaft/resolver/static.rb
+++ b/lib/propshaft/resolver/static.rb
@@ -20,7 +20,7 @@ module Propshaft::Resolver
 
     private
       def parsed_manifest
-        @parsed_manifest ||= JSON.parse(manifest_path.read)
+        @parsed_manifest ||= JSON.parse(manifest_path.read, symbolize_names: false)
       end
   end
 end

--- a/test/propshaft/resolver/static_test.rb
+++ b/test/propshaft/resolver/static_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/mock"
 require "propshaft/resolver/static"
 
 class Propshaft::Resolver::StaticTest < ActiveSupport::TestCase
@@ -21,5 +22,16 @@ class Propshaft::Resolver::StaticTest < ActiveSupport::TestCase
 
   test "resolving missing asset returns nil" do
     assert_nil @resolver.resolve("nowhere.txt")
+  end
+
+  test "resolver requests json optimizer gems to keep parsed manifest keys as strings" do
+    stub = Proc.new do |_, opts|
+      assert_equal false, opts[:symbolize_names]
+      {}
+    end
+
+    JSON.stub :parse, stub do
+      @resolver.resolve("one.txt")
+    end
   end
 end


### PR DESCRIPTION
Closes #84

Add `symbolize_names: false` param when parsing the manifest.