### PR TITLE
Silence asset requests with config.assets.quiet

### DIFF
--- a/lib/propshaft/quiet_assets.rb
+++ b/lib/propshaft/quiet_assets.rb
@@ -1,0 +1,14 @@
+class Propshaft::QuietAssets
+  def initialize(app)
+    @app = app
+    @assets_regex = %r(\A/{0,2}#{::Rails.application.config.assets.prefix})
+  end
+
+  def call(env)
+    if env['PATH_INFO'] =~ @assets_regex
+      ::Rails.logger.silence { @app.call(env) }
+    else
+      @app.call(env)
+    end
+  end
+end

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -1,5 +1,6 @@
 require "rails"
 require "active_support/ordered_options"
+require "propshaft/quiet_assets"
 
 module Propshaft
   class Railtie < ::Rails::Railtie
@@ -8,6 +9,7 @@ module Propshaft
     config.assets.excluded_paths = []
     config.assets.version        = "1"
     config.assets.prefix         = "/assets"
+    config.assets.quiet          = false
     config.assets.compilers      = [
       [ "text/css", Propshaft::Compilers::CssAssetUrls ],
       [ "text/css", Propshaft::Compilers::SourceMappingUrls ],
@@ -54,6 +56,12 @@ module Propshaft
       Propshaft.logger = config.assets.logger || Rails.logger
     end
 
+    initializer :quiet_assets do |app|
+      if app.config.assets.quiet
+        app.middleware.insert_before ::Rails::Rack::Logger, Propshaft::QuietAssets
+      end
+    end
+
     rake_tasks do
       load "propshaft/railties/assets.rake"
     end
@@ -61,7 +69,6 @@ module Propshaft
     # Compatibility shiming (need to provide log warnings when used)
     config.assets.precompile     = []
     config.assets.debug          = nil
-    config.assets.quiet          = nil
     config.assets.compile        = nil
     config.assets.version        = nil
     config.assets.css_compressor = nil

--- a/test/propshaft/quiet_assets_test.rb
+++ b/test/propshaft/quiet_assets_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "propshaft/quiet_assets"
+
+class Propshaft::QuietAssetsTest < ActiveSupport::TestCase
+  setup do
+    Rails.logger.level = Logger::DEBUG
+  end
+
+  test "silences with default prefix" do
+    assert_equal Logger::ERROR, middleware.call("PATH_INFO" => "/assets/stylesheets/application.css")
+  end
+
+  test "silences with custom prefix" do
+    original = Rails.application.config.assets.prefix
+    Rails.application.config.assets.prefix = "path/to"
+    assert_equal Logger::ERROR, middleware.call("PATH_INFO" => "/path/to/thing")
+  ensure
+    Rails.application.config.assets.prefix = original
+  end
+
+  test "does not silence without match" do
+    assert_equal Logger::DEBUG, middleware.call("PATH_INFO" => "/path/to/thing")
+  end
+
+  private
+
+  def middleware
+    @middleware ||= Propshaft::QuietAssets.new(->(env) { Rails.logger.level })
+  end
+end


### PR DESCRIPTION
I've been enjoying using propshaft but noticed that asset requests were not being silenced in my Rails app. This PR enables logger silencing with middleware when `config.assets.quiet = true`. I adapted most of this from https://github.com/rails/sprockets-rails/pull/355.