### PR TITLE
Update version when a cache sweep is performed

### DIFF
--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -64,6 +64,7 @@ class Propshaft::LoadPath
 
     def clear_cache
       @cached_assets_by_path = nil
+      @version = DateTime.new
     end
 
     def dedup(paths)

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -7,7 +7,7 @@ module Propshaft
     config.assets = ActiveSupport::OrderedOptions.new
     config.assets.paths          = []
     config.assets.excluded_paths = []
-    config.assets.version        = "1"
+    config.assets.version        = Rails.env.development? ? DateTime.new : "1"
     config.assets.prefix         = "/assets"
     config.assets.quiet          = false
     config.assets.compilers      = [


### PR DESCRIPTION
Closes #90

@dhh I think this is the simplest option we have. Use a timestamp as the cache version in development, and update it after every cache sweep. Only downside is that it will cause the browser to have to redownload every asset instead of just the one that was modified, since all digests will change.