### PR TITLE
Handle SVG mask URL with encoded anchor

### DIFF
--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -3,7 +3,7 @@
 class Propshaft::Compilers::CssAssetUrls
   attr_reader :assembly
 
-  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|data|http|\/\/))([^"'\s?#)]+)([#?][^"')]+)?\s*["']?\)/
+  ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|%23|data|http|\/\/))([^"'\s?#)]+)([#?][^"')]+)?\s*["']?\)/
 
   def initialize(assembly)
     @assembly = assembly

--- a/test/propshaft/compilers/css_asset_urls_test.rb
+++ b/test/propshaft/compilers/css_asset_urls_test.rb
@@ -105,6 +105,11 @@ class Propshaft::Compilers::CssAssetUrlsTest < ActiveSupport::TestCase
     assert_match(/{ content: url\("\/assets\/foobar\/source\/file-[a-z0-9]{40}.svg#rails"\); }/, compiled)
   end
 
+  test "svg mask encoded anchor" do
+    compiled = compile_asset_with_content(%({ background: url("data:image/svg+xml;charset=utf-8,%3Csvg mask='url(%23MyMask)'%3E%3C/svg%3E"); }))
+    assert_match "{ background: url(\"data:image/svg+xml;charset=utf-8,%3Csvg mask='url(%23MyMask)'%3E%3C/svg%3E\"); }", compiled
+  end
+
   test "non greedy anchors" do
     compiled = compile_asset_with_content(%({ content: url(file.svg#demo) url(file.svg#demo); }))
     assert_match(/{ content: url\("\/assets\/foobar\/source\/file-[a-z0-9]{40}.svg#demo"\) url\("\/assets\/foobar\/source\/file-[a-z0-9]{40}.svg#demo"\); }/, compiled)


### PR DESCRIPTION
This patch ensures that CSS assets with inlined SVG containing a mask
URL with an HTML encoded anchor are properly handled by the
`CssAssetUrls` compiler.

This avoids printing warning messages like:
```
Unable to resolve '%23c' for missing asset '%23c' in XYZ.css
```