### PR TITLE
Warn when precompiling assets in development

### DIFF
--- a/lib/propshaft/railties/assets.rake
+++ b/lib/propshaft/railties/assets.rake
@@ -2,6 +2,10 @@ namespace :assets do
   desc "Compile all the assets from config.assets.paths"
   task precompile: :environment do
     Rails.application.assets.processor.process
+    if Rails.env.development?
+      puts "Warning: You are precompiling assets in development. Rails will not " \
+        "serve any changed assets until you delete public/assets/.manifest.json"
+    end
   end
 
   desc "Remove config.assets.output_path"


### PR DESCRIPTION
Per #97 this adds a warning when doing `rails assets:precompile` in development

I don't know what the preferred wording is, and also the default logging in a fresh Rails 7 app seems to be writing this to `log/development.log` but not emitting it to the console's STDERR - not sure if that is desirable?