### PR TITLE
Define `Rails::Application.assets=` if it doesn’t exist

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -33,6 +33,8 @@ module Propshaft
       config.assets.output_path ||=
         Pathname.new(File.join(app.config.paths["public"].first, app.config.assets.prefix))
 
+      app.singleton_class.attr_accessor(:assets) unless app.respond_to?(:assets=)
+
       app.assets = Propshaft::Assembly.new(app.config.assets)
 
       if config.assets.server


### PR DESCRIPTION
Propshaft’s railtie sets an `Assembly` instance on `Rails::Application` via `app.assets=`. This mirrors Sprockets setting its own `Environment` instance there. But, as of https://github.com/rails/rails/pull/45878, the attr_accessor is no longer defined on the base class. So we have to define it here.

(The alternative to this is that we revert the rails PR 🤷‍♂️)