### PR TITLE
Improved migration guide for rails applications

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -251,6 +251,12 @@ It's a common pattern in apps to inline small SVG files and low resolution versi
 Rails.application.assets.load_path.find('logo.svg').content
 ```
 
+As Rails escapes html tags in views by default, in order to output a rendered svg you will need to specify rails not to escape the string using [html_safe](https://api.rubyonrails.org/classes/String.html#method-i-html_safe) or [raw]((https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html#method-i-raw).
+```ruby
+Rails.application.assets.load_path.find('logo.svg').html_safe
+raw Rails.application.assets.load_path.find('logo.svg')
+```
+
 **Precompilation in development**
 
 Propshaft uses a dynamic assets resolver in development mode. However, when you run `assets:precompile` locally Propshaft will then switch to a static assets resolver. Therefore, changes to assets will not be observed anymore and you will have to precompile the assets each time changes are made. This is different to Sprockets.


### PR DESCRIPTION
Adding details for displaying inline svg's with propshaft using html_safe or raw function.