### PR TITLE
ability to specify cache-control header in config

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -15,6 +15,11 @@ module Propshaft
       [ "text/css", Propshaft::Compilers::SourceMappingUrls ],
       [ "text/javascript", Propshaft::Compilers::SourceMappingUrls ]
     ]
+    if Rails.env.development?
+      config.assets.cache_control_header = "no-store"
+    else
+      config.assets.cache_control_header = "public, max-age=31536000, immutable"
+    end
     config.assets.sweep_cache = Rails.env.development?
     config.assets.server = Rails.env.development? || Rails.env.test?
 

--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -18,7 +18,7 @@ class Propshaft::Server
           "content-type"    => asset.content_type.to_s,
           "accept-encoding" => "vary",
           "etag"            => asset.digest,
-          "cache-control"   => "public, max-age=31536000, immutable"
+          "cache-control"   => Rails.application.config.assets.cache_control_header
         },
         [ compiled_content ]
       ]


### PR DESCRIPTION
Ability to tell what cache-control header we want the assets loaded with

This will solve the issue https://github.com/rails/propshaft/issues/90

Solution proposed by @dhh  in [issue 94](https://github.com/rails/propshaft/pull/94#issuecomment-1355086241) :

<img width="527" alt="Screenshot 2022-12-29 at 21 07 56" src="https://user-images.githubusercontent.com/721990/210006440-d89176da-3258-4398-9dfa-dc482cb4bb7b.png">

two things here:

#### 1. no-cache header

 `no-cache` works but maybe `no-store`  is more what we want ([source](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control))
<img width="756" alt="Screenshot 2022-12-29 at 21 09 50" src="https://user-images.githubusercontent.com/721990/210006599-7b4806e3-716c-4568-9f43-49bda1216b50.png">

... I don't mind either 

#### 2. this could be simpler?

I'm not sure if I didn't overkill this. Maybe something simpler would be enough eg:

```
# lib/propshaft/server.rb
       {
          #...
          "cache-control"   => Rails.development? ? 'no-store' : "public, max-age=31536000, immutable"
       }
```

...let me know I can simplify it
