### PR TITLE
Adds support for relative url root

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -8,10 +8,11 @@ require "propshaft/compilers/css_asset_urls"
 require "propshaft/compilers/source_mapping_urls"
 
 class Propshaft::Assembly
-  attr_reader :config
+  attr_reader :config, :url_prefix
 
   def initialize(config)
     @config = config
+    @url_prefix = File.join(config.relative_url_root.to_s, config.prefix.to_s).chomp("/")
   end
 
   def load_path

--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -26,7 +26,7 @@ class Propshaft::Compilers::CssAssetUrls
 
     def asset_url(resolved_path, logical_path, fingerprint, pattern)
       if asset = assembly.load_path.find(resolved_path)
-        %[url("#{assembly.config.prefix}/#{asset.digested_path}#{fingerprint}")]
+        %[url("#{assembly.url_prefix}/#{asset.digested_path}#{fingerprint}")]
       else
         Propshaft.logger.warn "Unable to resolve '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}"
         %[url("#{pattern}")]

--- a/lib/propshaft/compilers/css_asset_urls.rb
+++ b/lib/propshaft/compilers/css_asset_urls.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 class Propshaft::Compilers::CssAssetUrls
-  attr_reader :assembly, :url_prefix
+  attr_reader :assembly
 
   ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|%23|data|http|\/\/))([^"'\s?#)]+)([#?][^"')]+)?\s*["']?\)/
 
   def initialize(assembly)
-    @assembly   = assembly
-    @url_prefix = File.join(assembly.config.host.to_s, assembly.config.prefix.to_s).chomp("/")
+    @assembly = assembly
   end
 
   def compile(logical_path, input)
@@ -27,7 +26,7 @@ class Propshaft::Compilers::CssAssetUrls
 
     def asset_url(resolved_path, logical_path, fingerprint, pattern)
       if asset = assembly.load_path.find(resolved_path)
-        %[url("#{url_prefix}/#{asset.digested_path}#{fingerprint}")]
+        %[url("#{assembly.config.prefix}/#{asset.digested_path}#{fingerprint}")]
       else
         Propshaft.logger.warn "Unable to resolve '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}"
         %[url("#{pattern}")]

--- a/lib/propshaft/compilers/source_mapping_urls.rb
+++ b/lib/propshaft/compilers/source_mapping_urls.rb
@@ -24,7 +24,7 @@ class Propshaft::Compilers::SourceMappingUrls
 
     def source_mapping_url(resolved_path, comment)
       if asset = assembly.load_path.find(resolved_path)
-        "#{comment}# sourceMappingURL=#{assembly.config.prefix}/#{asset.digested_path}"
+        "#{comment}# sourceMappingURL=#{assembly.url_prefix}/#{asset.digested_path}"
       else
         Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{resolved_path}' from #{resolved_path}"
         nil

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -17,7 +17,6 @@ module Propshaft
     ]
     config.assets.sweep_cache = Rails.env.development?
     config.assets.server = Rails.env.development? || Rails.env.test?
-    config.assets.host = nil
 
     # Register propshaft initializer to copy the assets path in all the Rails Engines.
     # This makes possible for us to keep all `assets` config in this Railtie, but still
@@ -31,7 +30,6 @@ module Propshaft
     end
 
     config.after_initialize do |app|
-      config.assets.host = app.config.asset_host
       config.assets.output_path ||=
         Pathname.new(File.join(app.config.paths["public"].first, app.config.assets.prefix))
 

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -17,6 +17,7 @@ module Propshaft
     ]
     config.assets.sweep_cache = Rails.env.development?
     config.assets.server = Rails.env.development? || Rails.env.test?
+    config.assets.relative_url_root = nil
 
     # Register propshaft initializer to copy the assets path in all the Rails Engines.
     # This makes possible for us to keep all `assets` config in this Railtie, but still
@@ -30,6 +31,7 @@ module Propshaft
     end
 
     config.after_initialize do |app|
+      config.assets.relative_url_root ||= app.config.relative_url_root
       config.assets.output_path ||=
         Pathname.new(File.join(app.config.paths["public"].first, app.config.assets.prefix))
 

--- a/test/propshaft/compilers/source_mapping_urls_test.rb
+++ b/test/propshaft/compilers/source_mapping_urls_test.rb
@@ -6,42 +6,56 @@ require "propshaft/compilers"
 
 class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
   setup do
-    @assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config| 
+    @options = ActiveSupport::OrderedOptions.new.tap { |config|
       config.paths = [ Pathname.new("#{__dir__}/../../fixtures/assets/mapped") ]
       config.output_path = Pathname.new("#{__dir__}/../../fixtures/output")
       config.prefix = "/assets"
-    })
-
-    @assembly.compilers.register "text/javascript", Propshaft::Compilers::SourceMappingUrls
-    @assembly.compilers.register "text/css", Propshaft::Compilers::SourceMappingUrls
+    }
   end
 
   test "matching source map" do
     assert_match %r{//# sourceMappingURL=/assets/source.js-[a-z0-9]{40}\.map},
-                 @assembly.compilers.compile(find_asset("source.js", fixture_path: "mapped"))
+                  compile_asset(find_asset("source.js", fixture_path: "mapped"))
     assert_match %r{/\*# sourceMappingURL=/assets/source.css-[a-z0-9]{40}\.map},
-                 @assembly.compilers.compile(find_asset("source.css", fixture_path: "mapped"))
+                  compile_asset(find_asset("source.css", fixture_path: "mapped"))
   end
 
   test "matching nested source map" do
     assert_match %r{//# sourceMappingURL=/assets/nested/another-source.js-[a-z0-9]{40}\.map},
-                 @assembly.compilers.compile(find_asset("nested/another-source.js", fixture_path: "mapped"))
+                  compile_asset(find_asset("nested/another-source.js", fixture_path: "mapped"))
   end
 
   test "missing source map" do
     assert_no_match %r{sourceMappingURL},
-                    @assembly.compilers.compile(find_asset("sourceless.js", fixture_path: "mapped"))
+                     compile_asset(find_asset("sourceless.js", fixture_path: "mapped"))
     assert_no_match %r{sourceMappingURL},
-                    @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
+                     compile_asset(find_asset("sourceless.css", fixture_path: "mapped"))
   end
 
   test "sourceMappingURL outside of a comment should be left alone" do
     assert_match %r{sourceMappingURL=sourceMappingURL-outside-comment.css.map},
-                 @assembly.compilers.compile(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
+                 compile_asset(find_asset("sourceMappingURL-outside-comment.css", fixture_path: "mapped"))
   end
 
   test "sourceMappingURL not at the beginning of the line should be left alone" do
     assert_match %r{sourceMappingURL=sourceMappingURL-not-at-start.css.map},
-                 @assembly.compilers.compile(find_asset("sourceMappingURL-not-at-start.css", fixture_path: "mapped"))
+                  compile_asset(find_asset("sourceMappingURL-not-at-start.css", fixture_path: "mapped"))
   end
+
+  test "relative url root" do
+    @options.relative_url_root = "/url-root"
+
+    assert_match %r{//# sourceMappingURL=/url-root/assets/source.js-[a-z0-9]{40}\.map},
+                  compile_asset(find_asset("source.js", fixture_path: "mapped"))
+  end
+
+  private
+    def compile_asset(asset)
+
+      assembly = Propshaft::Assembly.new(@options)
+      assembly.compilers.register "text/javascript", Propshaft::Compilers::SourceMappingUrls
+      assembly.compilers.register "text/css", Propshaft::Compilers::SourceMappingUrls
+
+      assembly.compilers.compile(asset)
+    end
 end


### PR DESCRIPTION
Closes https://github.com/rails/propshaft/issues/103

This builds on the changes in PR https://github.com/rails/propshaft/pull/118 to add support for relative_url_root 

It also extends both fixes to apply to the source mapping compiler. In doing so I have moved the derivation of the prefix to the Assembly to dry up the solution.

It is my first PR so let me know of anything I can do to improve it. 