### PR TITLE
Prevent damage to /* ... */ comments with missing source maps

### DIFF
--- a/lib/propshaft/compilers/source_mapping_urls.rb
+++ b/lib/propshaft/compilers/source_mapping_urls.rb
@@ -27,7 +27,7 @@ class Propshaft::Compilers::SourceMappingUrls
         "#{comment}# sourceMappingURL=#{assembly.config.prefix}/#{asset.digested_path}"
       else
         Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{resolved_path}' from #{resolved_path}"
-        nil
+        comment
       end
     end
 end

--- a/test/propshaft/compilers/source_mapping_urls_test.rb
+++ b/test/propshaft/compilers/source_mapping_urls_test.rb
@@ -6,7 +6,7 @@ require "propshaft/compilers"
 
 class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
   setup do
-    @assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config| 
+    @assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config|
       config.paths = [ Pathname.new("#{__dir__}/../../fixtures/assets/mapped") ]
       config.output_path = Pathname.new("#{__dir__}/../../fixtures/output")
       config.prefix = "/assets"
@@ -33,6 +33,11 @@ class Propshaft::Compilers::SourceMappingUrlsTest < ActiveSupport::TestCase
                     @assembly.compilers.compile(find_asset("sourceless.js", fixture_path: "mapped"))
     assert_no_match %r{sourceMappingURL},
                     @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
+  end
+
+  test "sourceMappingURL removal due to missing map does not damage /* ... */ comments" do
+    assert_match %r{\A#{Regexp.escape ".failure { color: red; }\n/* */\n"}\Z},
+                 @assembly.compilers.compile(find_asset("sourceless.css", fixture_path: "mapped"))
   end
 
   test "sourceMappingURL outside of a comment should be left alone" do


### PR DESCRIPTION
If a source map is missing in a JS or CSS file that uses the `/* ... */` style of comments, Propshaft would inadvertently substitute nothing via `gsub` for the opening comment as well as the source map part, leaving a broken trailing `*/`.

Fixed, with test coverage to prove it.