### PR TITLE
fix: Vary HTTP header

### DIFF
--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -16,7 +16,7 @@ class Propshaft::Server
         {
           "content-length"  => compiled_content.length.to_s,
           "content-type"    => asset.content_type.to_s,
-          "vary" => "Accept-Encoding",
+          "vary"            => "Accept-Encoding",
           "etag"            => asset.digest,
           "cache-control"   => "public, max-age=31536000, immutable"
         },

--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -16,7 +16,7 @@ class Propshaft::Server
         {
           "content-length"  => compiled_content.length.to_s,
           "content-type"    => asset.content_type.to_s,
-          "accept-encoding" => "vary",
+          "vary" => "Accept-Encoding",
           "etag"            => asset.digest,
           "cache-control"   => "public, max-age=31536000, immutable"
         },

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -22,7 +22,7 @@ class Propshaft::ServerTest < ActiveSupport::TestCase
     assert_equal 200, last_response.status
     assert_equal "94", last_response.headers['content-length']
     assert_equal "text/css", last_response.headers['content-type']
-    assert_equal "vary", last_response.headers['accept-encoding']
+    assert_equal "Accept-Encoding", last_response.headers['vary']
     assert_equal asset.digest, last_response.headers['etag']
     assert_equal "public, max-age=31536000, immutable", last_response.headers['cache-control']
     assert_equal ".hero { background: url(\"/foobar/source/file-3e6a129785ee3caf8eff23db339997e85334bfa9.jpg\") }\n",


### PR DESCRIPTION
`Accept-Encoding` is a request header. The intent here was to set the `Vary` header to prevent sending responses compressed with modern algorithms to old browsers and sending responses compressed with old suboptimal algorithms to modern browsers.