### PR TITLE
Fix markdown link in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -251,7 +251,7 @@ It's a common pattern in apps to inline small SVG files and low resolution versi
 Rails.application.assets.load_path.find('logo.svg').content
 ```
 
-As Rails escapes html tags in views by default, in order to output a rendered svg you will need to specify rails not to escape the string using [html_safe](https://api.rubyonrails.org/classes/String.html#method-i-html_safe) or [raw]((https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html#method-i-raw).
+As Rails escapes html tags in views by default, in order to output a rendered svg you will need to specify rails not to escape the string using [html_safe](https://api.rubyonrails.org/classes/String.html#method-i-html_safe) or [raw](https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html#method-i-raw).
 ```ruby
 Rails.application.assets.load_path.find('logo.svg').html_safe
 raw Rails.application.assets.load_path.find('logo.svg')


### PR DESCRIPTION
Fixes the markdown link for `raw` docs.