### PR TITLE
Fixes: Newly added files that are already digested aren't available in development

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -9,7 +9,7 @@ class Propshaft::Asset
   def initialize(path, logical_path:, version: nil)
     @path         = path
     @digest       = logical_path.to_s[PREDIGESTED_REGEX, 1]
-    @logical_path = Pathname.new(@digest ? logical_path.sub("-#{@digest}", "") : logical_path)
+    @logical_path = logical_path
     @version      = version
   end
 
@@ -30,7 +30,11 @@ class Propshaft::Asset
   end
 
   def digested_path
-    logical_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
+    if already_digested?
+      logical_path
+    else
+      logical_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
+    end
   end
 
   def fresh?(digest)
@@ -40,4 +44,10 @@ class Propshaft::Asset
   def ==(other_asset)
     logical_path.hash == other_asset.logical_path.hash
   end
+
+  private
+
+    def already_digested?
+      logical_path.to_s =~ PREDIGESTED_REGEX
+    end
 end

--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -32,10 +32,12 @@ class Propshaft::Server
   end
 
   private
+
     def extract_path_and_digest(env)
       full_path = Rack::Utils.unescape(env["PATH_INFO"].to_s.sub(/^\//, ""))
-      digest    = full_path[/-([0-9a-zA-Z]{7,128}(?:\.digested)?)\.[^.]+\z/, 1]
-      path      = digest ? full_path.sub("-#{digest}", "") : full_path
+      digest = full_path[/-([0-9a-zA-Z]{7,128}(?:\.digested)?)\.[^.]+\z/, 1]
+      is_predigested = digest.match(Propshaft::Asset.PREDIGESTED_REGEX)
+      path = digest && !is_predigested ? full_path.sub("-#{digest}", "") : full_path
 
       [ path, digest ]
     end


### PR DESCRIPTION
* makes sure that we don't remove the digest from the logical path if the asset is already digested
* related issue https://github.com/rails/propshaft/issues/139