### PR TITLE
Revert "feat(paths): allow assets to be found using their non digested path (#100)"

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -2,15 +2,10 @@ require "digest/sha1"
 require "action_dispatch/http/mime_type"
 
 class Propshaft::Asset
-  PREDIGESTED_REGEX = /-([0-9a-zA-Z]{7,128}\.digested)/
-
   attr_reader :path, :logical_path, :version
 
   def initialize(path, logical_path:, version: nil)
-    @path         = path
-    @digest       = logical_path.to_s[PREDIGESTED_REGEX, 1]
-    @logical_path = Pathname.new(@digest ? logical_path.sub("-#{@digest}", "") : logical_path)
-    @version      = version
+    @path, @logical_path, @version = path, Pathname.new(logical_path), version
   end
 
   def content
@@ -30,14 +25,23 @@ class Propshaft::Asset
   end
 
   def digested_path
-    logical_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
+    if already_digested?
+      logical_path
+    else
+      logical_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
+    end
   end
 
   def fresh?(digest)
-    self.digest == digest
+    self.digest == digest || already_digested?
   end
 
   def ==(other_asset)
     logical_path.hash == other_asset.logical_path.hash
   end
+
+  private
+    def already_digested?
+      logical_path.to_s =~ /-([0-9a-zA-Z]{7,128})\.digested/
+    end
 end

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -48,8 +48,7 @@ class Propshaft::LoadPath
         paths.each do |path|
           without_dotfiles(all_files_from_tree(path)).each do |file|
             logical_path = file.relative_path_from(path)
-            asset = Propshaft::Asset.new(file, logical_path: logical_path, version: version)
-            mapped[asset.logical_path.to_s] ||= asset
+            mapped[logical_path.to_s] ||= Propshaft::Asset.new(file, logical_path: logical_path, version: version)
           end if path.exist?
         end
       end

--- a/lib/propshaft/output_path.rb
+++ b/lib/propshaft/output_path.rb
@@ -42,7 +42,7 @@ class Propshaft::OutputPath
       modified_at = [ 0, Time.now - mtime ].max
       modified_at < expires_at || limit < count
     end
-
+  
     def remove(path)
       FileUtils.rm(@path.join(path))
       Propshaft.logger.info "Removed #{path}"

--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -11,8 +11,8 @@ class Propshaft::Server
     if (asset = @assembly.load_path.find(path)) && asset.fresh?(digest)
       compiled_content = @assembly.compilers.compile(asset)
 
-      [
-        200,
+      [ 
+        200, 
         {
           "content-length"  => compiled_content.length.to_s,
           "content-type"    => asset.content_type.to_s,
@@ -34,7 +34,7 @@ class Propshaft::Server
   private
     def extract_path_and_digest(env)
       full_path = Rack::Utils.unescape(env["PATH_INFO"].to_s.sub(/^\//, ""))
-      digest    = full_path[/-([0-9a-zA-Z]{7,128}(?:\.digested)?)\.[^.]+\z/, 1]
+      digest    = full_path[/-([0-9a-zA-Z]{7,128})\.(?!digested)[^.]+\z/, 1]
       path      = digest ? full_path.sub("-#{digest}", "") : full_path
 
       [ path, digest ]

--- a/test/fixtures/assets/first_path/file-already-abcdefVWXYZ0123456789.digested.debug.css
+++ b/test/fixtures/assets/first_path/file-already-abcdefVWXYZ0123456789.digested.debug.css
@@ -1,0 +1,5 @@
+/* this is css */
+
+.btn {
+    background-image: asset-path("archive.svg");
+}

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -25,8 +25,7 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     assert find_asset("one.txt").fresh?("f2e1ec14d6856e1958083094170ca6119c529a73")
     assert_not find_asset("one.txt").fresh?("e206c34fe404c8e2f25d60dd8303f61c02b8d381")
 
-    assert find_asset("file-already-abcdefVWXYZ0123456789.digested.css").fresh?("abcdefVWXYZ0123456789.digested")
-    assert_not find_asset("file-already-abcdefVWXYZ0123456789.digested.css").fresh?(nil)
+    assert find_asset("file-already-abcdefVWXYZ0123456789.digested.css").fresh?(nil)
   end
 
   test "digested path" do
@@ -35,6 +34,9 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
 
     assert_equal "file-already-abcdefVWXYZ0123456789.digested.css",
       find_asset("file-already-abcdefVWXYZ0123456789.digested.css").digested_path.to_s
+
+    assert_equal "file-already-abcdefVWXYZ0123456789.digested.debug.css",
+      find_asset("file-already-abcdefVWXYZ0123456789.digested.debug.css").digested_path.to_s
 
     assert_equal "file-not.digested-e206c34fe404c8e2f25d60dd8303f61c02b8d381.css",
       find_asset("file-not.digested.css").digested_path.to_s

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -39,7 +39,6 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
   test "manifest" do
     @load_path.manifest.tap do |manifest|
       assert_equal "one-f2e1ec14d6856e1958083094170ca6119c529a73.txt", manifest["one.txt"]
-      assert_equal "file-already-abcdefVWXYZ0123456789.digested.css", manifest["file-already.css"]
       assert_equal "nested/three-6c2b86a0206381310375abdd9980863c2ea7b2c3.txt", manifest["nested/three.txt"]
     end
   end

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -30,7 +30,7 @@ class Propshaft::ServerTest < ActiveSupport::TestCase
   end
 
   test "serve a predigested file" do
-    asset = @assembly.load_path.find("file-already.css")
+    asset = @assembly.load_path.find("file-already-abcdefVWXYZ0123456789.digested.css")
     get "/#{asset.digested_path}"
     assert_equal 200, last_response.status
   end


### PR DESCRIPTION
Closes #143 
Closes #139 
Might close #117 
Replaces #141

While this was a nice idea, once again issues show that trying to extract digests generated by bundlers causes compatibility problems. Let's revert so esbuild chunking works again and think of another way to do this.

@joker-777 Your PR seems to revert most of the changes here, so I think it might be a better idea to revert the entire thing. I've added you as a co-author.

I'm keeping this PR open for a while before merging in case anyone involved in the listed issues/PRs wants to provide further input.