### PR TITLE
Improve log message

### DIFF
--- a/lib/propshaft/compiler/source_mapping_urls.rb
+++ b/lib/propshaft/compiler/source_mapping_urls.rb
@@ -22,7 +22,7 @@ class Propshaft::Compiler::SourceMappingUrls < Propshaft::Compiler
       if asset = assembly.load_path.find(resolved_path)
         "#{comment}# sourceMappingURL=#{url_prefix}/#{asset.digested_path}"
       else
-        Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{resolved_path}' from #{resolved_path}"
+        Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{resolved_path}'"
         comment
       end
     end


### PR DESCRIPTION
`... '#{resolved_path}' from #{resolved_path}` makes no sense, as it references the same variable twice.

We can just drop the last one from the warning