### PR TITLE
Update warning message to use correct location

### DIFF
--- a/lib/propshaft/railties/assets.rake
+++ b/lib/propshaft/railties/assets.rake
@@ -4,7 +4,7 @@ namespace :assets do
     Rails.application.assets.processor.process
     if Rails.env.development?
       puts "Warning: You are precompiling assets in development. Rails will not " \
-        "serve any changed assets until you delete public/assets/.manifest.json"
+        "serve any changed assets until you delete public#{Rails.application.config.assets.prefix}/.manifest.json"
     end
   end
 


### PR DESCRIPTION
When the `assets.prefix` rails configuration value has been changed, this will result in the manifest file being written into a different directory underneath `/public`

By using this dynamic value in the warning message, it should provide the correct path to the manifest file