### PR TITLE
Configure Cache Sweeper to Also Run in "test" Environment

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -15,7 +15,7 @@ module Propshaft
       [ "text/css", Propshaft::Compiler::SourceMappingUrls ],
       [ "text/javascript", Propshaft::Compiler::SourceMappingUrls ]
     ]
-    config.assets.sweep_cache = Rails.env.development?
+    config.assets.sweep_cache = Rails.env.development? || Rails.env.test?
     config.assets.server = Rails.env.development? || Rails.env.test?
     config.assets.relative_url_root = nil
 


### PR DESCRIPTION
Cache sweeper is not being used in "test" environment. 

When using `dartsass-rails` - we're running `dartsass:build` before kicking off RSpec tests. However, we're doing that when RSpec is initializing - so after Propshaft is initialized. When `dartsass` creates files in `assets/builds` - they're not picked up by Propshaft because cache sweeper is inactive in test.

Looking at file `load_path` I can see this documentation

```ruby
# Returns a file watcher object configured to clear the cache of the load_path
# when the directories passed during its initialization have changes. This is used in development
# and test to ensure the map caches are reset when javascript files are changed.
def cache_sweeper
end
```

Which suggests that cache sweeper should be running in `test` environment. So this PR is updating `railtie.rb` and sets cache sweeper to run in test by default.