### PR TITLE
Add support for digest_class config

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -15,7 +15,11 @@ class Propshaft::Assembly
   end
 
   def load_path
-    @load_path ||= Propshaft::LoadPath.new(config.paths, version: config.version)
+    @load_path ||= Propshaft::LoadPath.new(
+      config.paths,
+      version: config.version,
+      digest_class: confing.digest_class,
+    )
   end
 
   def resolver
@@ -46,7 +50,7 @@ class Propshaft::Assembly
 
   def reveal(path_type = :logical_path)
     path_type = path_type.presence_in(%i[ logical_path path ]) || raise(ArgumentError, "Unknown path_type: #{path_type}")
-    
+
     load_path.assets.collect do |asset|
       asset.send(path_type)
     end

--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -18,7 +18,7 @@ class Propshaft::Assembly
     @load_path ||= Propshaft::LoadPath.new(
       config.paths,
       version: config.version,
-      digest_class: confing.digest_class,
+      digest_class: config.digest_class,
     )
   end
 

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -2,10 +2,13 @@ require "digest/sha1"
 require "action_dispatch/http/mime_type"
 
 class Propshaft::Asset
-  attr_reader :path, :logical_path, :version
+  attr_reader :path, :logical_path, :digest_class, :version
 
-  def initialize(path, logical_path:, version: nil)
-    @path, @logical_path, @version = path, Pathname.new(logical_path), version
+  def initialize(path, logical_path:, digest_class: Digest::SHA1, version: nil)
+    @path         = path
+    @logical_path = Pathname.new(logical_path)
+    @digest_class = digest_class
+    @version      = version
   end
 
   def content
@@ -21,7 +24,7 @@ class Propshaft::Asset
   end
 
   def digest
-    @digest ||= Digest::SHA1.hexdigest("#{content}#{version}")
+    @digest ||= digest_class.hexdigest("#{content}#{version}")
   end
 
   def digested_path

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -1,11 +1,12 @@
 require "propshaft/asset"
 
 class Propshaft::LoadPath
-  attr_reader :paths, :version
+  attr_reader :paths, :digest_class, :version
 
-  def initialize(paths = [], version: nil)
-    @paths   = dedup(paths)
-    @version = version
+  def initialize(paths = [], digest_class: Digest::SHA1, version: nil)
+    @paths        = dedup(paths)
+    @version      = version
+    @digest_class = digest_class
   end
 
   def find(asset_name)
@@ -48,7 +49,12 @@ class Propshaft::LoadPath
         paths.each do |path|
           without_dotfiles(all_files_from_tree(path)).each do |file|
             logical_path = file.relative_path_from(path)
-            mapped[logical_path.to_s] ||= Propshaft::Asset.new(file, logical_path: logical_path, version: version)
+            mapped[logical_path.to_s] ||= Propshaft::Asset.new(
+              file,
+              logical_path: logical_path,
+              version: version,
+              digest_class: digest_class,
+            )
           end if path.exist?
         end
       end

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -18,6 +18,7 @@ module Propshaft
     config.assets.sweep_cache = Rails.env.development?
     config.assets.server = Rails.env.development? || Rails.env.test?
     config.assets.relative_url_root = nil
+    config.assets.digest_class = Digest::SHA1
 
     # Register propshaft initializer to copy the assets path in all the Rails Engines.
     # This makes possible for us to keep all `assets` config in this Railtie, but still

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -61,6 +61,9 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     def find_asset(logical_path, digest_class: nil)
       root_path = Pathname.new("#{__dir__}/../fixtures/assets/first_path")
       path = root_path.join(logical_path)
-      Propshaft::Asset.new(path, **{ logical_path: logical_path, digest_class: }.compact)
+      Propshaft::Asset.new(
+        path,
+        **{ logical_path: logical_path, digest_class: digest_class }.compact,
+      )
     end
 end

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -51,10 +51,16 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     assert_equal asset.digest.object_id, asset.digest.object_id
   end
 
+  test "custom digest class" do
+    asset = find_asset("one.txt", digest_class: Digest::SHA256)
+    assert_equal "one-f82fcaff474fbc87520bcae5fcd0d2f33a8fa74f11d151fe84a30ce03f2d349b.txt",
+      asset.digested_path.to_s
+  end
+
   private
-    def find_asset(logical_path)
+    def find_asset(logical_path, digest_class: nil)
       root_path = Pathname.new("#{__dir__}/../fixtures/assets/first_path")
       path = root_path.join(logical_path)
-      Propshaft::Asset.new(path, logical_path: logical_path)
+      Propshaft::Asset.new(path, **{ logical_path: logical_path, digest_class: }.compact)
     end
 end

--- a/test/propshaft/compiler/css_asset_urls_test.rb
+++ b/test/propshaft/compiler/css_asset_urls_test.rb
@@ -10,6 +10,7 @@ class Propshaft::Compiler::CssAssetUrlsTest < ActiveSupport::TestCase
       config.paths = [ Pathname.new("#{__dir__}/../../fixtures/assets/vendor") ]
       config.output_path = Pathname.new("#{__dir__}/../../fixtures/output")
       config.prefix = "/assets"
+      config.digest_class = Digest::SHA1
     }
   end
 

--- a/test/propshaft/compiler/source_mapping_urls_test.rb
+++ b/test/propshaft/compiler/source_mapping_urls_test.rb
@@ -10,6 +10,7 @@ class Propshaft::Compiler::SourceMappingUrlsTest < ActiveSupport::TestCase
       config.paths = [ Pathname.new("#{__dir__}/../../fixtures/assets/mapped") ]
       config.output_path = Pathname.new("#{__dir__}/../../fixtures/output")
       config.prefix = "/assets"
+      config.digest_class = Digest::SHA1
     }
   end
 

--- a/test/propshaft/compilers_test.rb
+++ b/test/propshaft/compilers_test.rb
@@ -9,6 +9,7 @@ class Propshaft::CompilersTest < ActiveSupport::TestCase
       config.paths = [ Pathname.new("#{__dir__}/../fixtures/assets/first_path") ]
       config.output_path = Pathname.new("#{__dir__}/../fixtures/output")
       config.prefix = "/assets"
+      config.digest_class = Digest::SHA1
     })
   end
 

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -55,6 +55,14 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     assert_nil Propshaft::LoadPath.new(Pathname.new("#{__dir__}/../fixtures/assets/nowhere")).find("missing")
   end
 
+  test "custom digest class" do
+    @load_path = Propshaft::LoadPath.new(@load_path.paths, version: "1", digest_class: Digest::SHA256)
+    @load_path.manifest.tap do |manifest|
+      assert_equal "one-eb08cb2ea42bc732b848716bbc062289448f1bd3c12c5949aeb80f511c9bb99a.txt", manifest["one.txt"]
+      assert_equal "nested/three-68540fa36185a8a95d7d6b34d96915f466204e8b72fb1292aafdc6086547df26.txt", manifest["nested/three.txt"]
+    end
+  end
+
   test "deduplicate paths" do
     load_path = Propshaft::LoadPath.new [
       "app/javascript",

--- a/test/propshaft/processor_test.rb
+++ b/test/propshaft/processor_test.rb
@@ -11,6 +11,7 @@ class Propshaft::ProcessorTest < ActiveSupport::TestCase
         Pathname.new("#{__dir__}/../fixtures/assets/first_path"),
         Pathname.new("#{__dir__}/../fixtures/assets/second_path")
       ]
+      config.digest_class = Digest::SHA1
     })
   end
 

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -9,6 +9,7 @@ class Propshaft::ServerTest < ActiveSupport::TestCase
     @assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config|
       config.paths = [Pathname.new("#{__dir__}/../fixtures/assets/vendor"), Pathname.new("#{__dir__}/../fixtures/assets/first_path")]
       config.output_path = Pathname.new("#{__dir__}../fixtures/output")
+      config.digest_class = Digest::SHA1
     })
 
     @assembly.compilers.register "text/css", Propshaft::Compiler::CssAssetUrls


### PR DESCRIPTION
This pull request proposes to add support for a `digest_class` configuration, to override the behavior of asset digesting.

**Why?**

- More control over how the digest is computed.
   - In our use-case, my interest is more in being able to shorten the length of the digest from 32 characters to 7 or 8 characters, and this is a roundabout way of doing that while offering greater overall control.
- Feature parity with [the equivalent Sprockets configuration](https://github.com/rails/sprockets/blob/5b040f3bec503ded8a98c0c911c7a77dd1f5bf1b/lib/sprockets.rb#L26), to streamline the process of migrating from Sprockets to Propshaft.

**Open Questions:**

- Should this have any impact on the behavior of `already_digested?`, whose implementation may vary depending on the digest logic?
- Is there a better way to "pass down" configuration options than carrying along the constructor argument as proposed here?
   - I was largely following the prior art of how `version` was passed along
- If there's not an interest in adding this configuration, would there be more reception to either (a) allowing the digest length to be configuration, or (b) changing the default to a shorter length? Either of these would satisfy at least my own intended use-case.