### PR TITLE
Require rack/version for Rack::RELEASE constant

### DIFF
--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -1,4 +1,5 @@
 require "rack/utils"
+require "rack/version"
 
 class Propshaft::Server
   def initialize(assembly)


### PR DESCRIPTION
Addresses `uninitialized constant Rack::RELEASE (NameError)` in cases where propshaft is required before `rack`.