### PR TITLE
Update action version in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: ${{ matrix.continue-on-error }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR updates the CI workflow to use the latest version (v4) of the checkout action