### PR TITLE
Improve source mapping compiler log message

### DIFF
--- a/lib/propshaft/compiler/source_mapping_urls.rb
+++ b/lib/propshaft/compiler/source_mapping_urls.rb
@@ -6,7 +6,7 @@ class Propshaft::Compiler::SourceMappingUrls < Propshaft::Compiler
   SOURCE_MAPPING_PATTERN = %r{(//|/\*)# sourceMappingURL=(.+\.map)(\s*?\*\/)?\s*?\Z}
 
   def compile(logical_path, input)
-    input.gsub(SOURCE_MAPPING_PATTERN) { source_mapping_url(asset_path($2, logical_path), $1, $3) }
+    input.gsub(SOURCE_MAPPING_PATTERN) { source_mapping_url(logical_path, asset_path($2, logical_path), $1, $3) }
   end
 
   private
@@ -18,11 +18,11 @@ class Propshaft::Compiler::SourceMappingUrls < Propshaft::Compiler
       end
     end
 
-    def source_mapping_url(resolved_path, comment_start, comment_end)
+    def source_mapping_url(logical_path, resolved_path, comment_start, comment_end)
       if asset = assembly.load_path.find(resolved_path)
         "#{comment_start}# sourceMappingURL=#{url_prefix}/#{asset.digested_path}#{comment_end}"
       else
-        Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{resolved_path}' from #{resolved_path}"
+        Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{resolved_path}' from #{logical_path}"
         "#{comment_start}#{comment_end}"
       end
     end


### PR DESCRIPTION
Improves previous PR https://github.com/rails/propshaft/pull/145.

Now the `logical_path` is properly logged, making it easier to find the problem.

