### PR TITLE
Adds the assets:clean[count] parameter

### DIFF
--- a/lib/propshaft/processor.rb
+++ b/lib/propshaft/processor.rb
@@ -20,8 +20,8 @@ class Propshaft::Processor
     FileUtils.rm_r(output_path) if File.exist?(output_path)
   end
 
-  def clean
-    Propshaft::OutputPath.new(output_path, load_path.manifest).clean(2, 1.hour)
+  def clean(count)
+    Propshaft::OutputPath.new(output_path, load_path.manifest).clean(count, 1.hour)
   end
 
   private

--- a/lib/propshaft/railties/assets.rake
+++ b/lib/propshaft/railties/assets.rake
@@ -14,8 +14,9 @@ namespace :assets do
   end
 
   desc "Removes old files in config.assets.output_path"
-  task clean: :environment do
-    Rails.application.assets.processor.clean
+  task :clean, [:count] => [:environment] do |_, args|
+    count = args.fetch(:count, 2)
+    Rails.application.assets.processor.clean(count.to_i)
   end
 
   desc "Print all the assets available in config.assets.paths"


### PR DESCRIPTION
Sprockets supported the parameterized `clean` Rake task, to keep the `:count` latest assets versions. IIRC webpacker supported it as well.

If you deployed with Capistrano, this was configurable via the `:keep_assets` [config](https://github.com/capistrano/rails/blob/master/lib/capistrano/tasks/assets.rake#L33).

This PR adds this to propshaft's clean task as well instead of the hardcoded `2`.