### PR TITLE
Fix typo in "Asset content" section of UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -253,8 +253,8 @@ Rails.application.assets.load_path.find('logo.svg').content
 
 As Rails escapes html tags in views by default, in order to output a rendered svg you will need to specify rails not to escape the string using [html_safe](https://api.rubyonrails.org/classes/String.html#method-i-html_safe) or [raw](https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html#method-i-raw).
 ```ruby
-Rails.application.assets.load_path.find('logo.svg').html_safe
-raw Rails.application.assets.load_path.find('logo.svg')
+Rails.application.assets.load_path.find('logo.svg').content.html_safe
+raw Rails.application.assets.load_path.find('logo.svg').content
 ```
 
 **Precompilation in development**


### PR DESCRIPTION
When referring to how to escape HTML tags, the documentation forgot to call the `content` method.

When using `html_safe`, an exception will be raised because `html_safe` is not defined on `Propshaft::Asset`.

Using `raw`, on the other hand, will call `to_s` on the `Propshaft::Asset` instance, returning an expected tag