### PR TITLE
Maintain sourcemap file extensions

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -28,7 +28,7 @@ class Propshaft::Asset
     if already_digested?
       logical_path
     else
-      logical_path.sub(/\.(\w+)$/) { |ext| "-#{digest}#{ext}" }
+      logical_path.sub(/\.(\w+(\.map)?)$/) { |ext| "-#{digest}#{ext}" }
     end
   end
 

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -40,6 +40,9 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
 
     assert_equal "file-not.digested-e206c34fe404c8e2f25d60dd8303f61c02b8d381.css",
       find_asset("file-not.digested.css").digested_path.to_s
+
+    assert_equal "file-is-a-sourcemap-da39a3ee5e6b4b0d3255bfef95601890afd80709.js.map",
+      find_asset("file-is-a-sourcemap.js.map").digested_path.to_s
   end
 
   test "value object equality" do

--- a/test/propshaft/compiler/source_mapping_urls_test.rb
+++ b/test/propshaft/compiler/source_mapping_urls_test.rb
@@ -14,14 +14,14 @@ class Propshaft::Compiler::SourceMappingUrlsTest < ActiveSupport::TestCase
   end
 
   test "matching source map" do
-    assert_match %r{//# sourceMappingURL=/assets/source.js-[a-z0-9]{40}\.map},
+    assert_match %r{//# sourceMappingURL=/assets/source-[a-z0-9]{40}\.js.map},
                  compile_asset(find_asset("source.js", fixture_path: "mapped"))
-    assert_match %r{/\*# sourceMappingURL=/assets/source.css-[a-z0-9]{40}\.map},
+    assert_match %r{/\*# sourceMappingURL=/assets/source-[a-z0-9]{40}\.css.map},
                  compile_asset(find_asset("source.css", fixture_path: "mapped"))
   end
 
   test "matching nested source map" do
-    assert_match %r{//# sourceMappingURL=/assets/nested/another-source.js-[a-z0-9]{40}\.map},
+    assert_match %r{//# sourceMappingURL=/assets/nested/another-source-[a-z0-9]{40}\.js.map},
                  compile_asset(find_asset("nested/another-source.js", fixture_path: "mapped"))
   end
 
@@ -38,9 +38,9 @@ class Propshaft::Compiler::SourceMappingUrlsTest < ActiveSupport::TestCase
   end
 
   test "sourceMappingURL not at the beginning of the line, but at end of file, is processed" do
-    assert_match %r{//# sourceMappingURL=/assets/sourceMappingURL-not-at-start.js-[a-z0-9]{40}\.map},
+    assert_match %r{//# sourceMappingURL=/assets/sourceMappingURL-not-at-start-[a-z0-9]{40}\.js.map},
                  compile_asset(find_asset("sourceMappingURL-not-at-start.js", fixture_path: "mapped"))
-    assert_match %r{/\*# sourceMappingURL=/assets/sourceMappingURL-not-at-start.css-[a-z0-9]{40}\.map \*/},
+    assert_match %r{/\*# sourceMappingURL=/assets/sourceMappingURL-not-at-start-[a-z0-9]{40}\.css.map \*/},
                  compile_asset(find_asset("sourceMappingURL-not-at-start.css", fixture_path: "mapped"))
   end
 
@@ -56,7 +56,7 @@ class Propshaft::Compiler::SourceMappingUrlsTest < ActiveSupport::TestCase
   test "relative url root" do
     @options.relative_url_root = "/url-root"
 
-    assert_match %r{//# sourceMappingURL=/url-root/assets/source.js-[a-z0-9]{40}\.map},
+    assert_match %r{//# sourceMappingURL=/url-root/assets/source-[a-z0-9]{40}\.js.map},
                   compile_asset(find_asset("source.js", fixture_path: "mapped"))
   end
 


### PR DESCRIPTION
The regular expression for generating digested paths in propshaft is updated to accommodate sourcemap files.  This will ensure the digested sourcemaps end `-sha.ext.map` instead of `ext-sha.map`. Services like Datadog that allow sourcemap uploads look specifically for files ending with `.js.map`, so this change allows compatibility. A corresponding test has been added in asset_test.rb, verifying that sourcemap files are correctly digesting their paths.