### PR TITLE
Don't say this is beta software [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ But for greenfield apps using the default import-map approach, Propshaft can als
 
 ## Will Propshaft replace Sprockets as the Rails default?
 
-Most likely, but Sprockets needs to be supported as well for a long time to come. Plenty of apps and gems were built on Sprocket features, and they won't be migrating soon. Still working out the compatibility story. This is very much beta software at the moment.
+Most likely, but Sprockets needs to be supported as well for a long time to come. Plenty of apps and gems were built on Sprocket features, and they won't be migrating soon. Still working out the compatibility story.
 
 
 ## License


### PR DESCRIPTION
Since many production apps like [HEY have been using this](https://twitter.com/dhh/status/1491843448881692679) for years now, I think it's safe to remove this warning. Personally, I was kinda scared of using this in my apps until I saw the full story.