### PR TITLE
Dependency aware asset digests

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -6,6 +6,7 @@ require "propshaft/processor"
 require "propshaft/compilers"
 require "propshaft/compiler/css_asset_urls"
 require "propshaft/compiler/source_mapping_urls"
+require "propshaft/dependency_tree"
 
 class Propshaft::Assembly
   attr_reader :config
@@ -15,7 +16,7 @@ class Propshaft::Assembly
   end
 
   def load_path
-    @load_path ||= Propshaft::LoadPath.new(config.paths, version: config.version)
+    @load_path ||= Propshaft::LoadPath.new(config.paths, version: config.version, dependency_tree: dependency_tree)
   end
 
   def resolver
@@ -24,6 +25,10 @@ class Propshaft::Assembly
     else
       Propshaft::Resolver::Dynamic.new load_path: load_path, prefix: config.prefix
     end
+  end
+
+  def dependency_tree
+    Propshaft::DependencyTree.new(compilers: compilers)
   end
 
   def server

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -3,9 +3,12 @@ require "action_dispatch/http/mime_type"
 
 class Propshaft::Asset
   attr_reader :path, :logical_path, :version
+  attr_accessor :dependencies, :dependency_fingerprint
 
   def initialize(path, logical_path:, version: nil)
     @path, @logical_path, @version = path, Pathname.new(logical_path), version
+    @dependencies = nil
+    @dependency_fingerprint = nil
   end
 
   def content
@@ -16,12 +19,27 @@ class Propshaft::Asset
     Mime::Type.lookup_by_extension(logical_path.extname.from(1))
   end
 
+  def may_depend?
+    content_type&.symbol == :css
+  end
+
   def length
     content.size
   end
 
+  # A dependency aware digest can be calculated for any asset that has no dependencies or
+  # that has had its dependency fingerprint set by DependencyTree.
+  # If it's too soon, we can still calculate the digest based on file contents,
+  # but there won't be any dependency cache busting.
+  def digest_too_soon?
+    may_depend? && dependencies&.any? && !dependency_fingerprint
+  end
+
   def digest
-    @digest ||= Digest::SHA1.hexdigest("#{content}#{version}").first(8)
+    @digest ||= begin
+      Propshaft.logger.warn("digest dependencies not ready for #{logical_path}") if digest_too_soon?
+      Digest::SHA1.hexdigest("#{content}#{version}#{dependency_fingerprint}").first(8)
+    end
   end
 
   def digested_path

--- a/lib/propshaft/compiler.rb
+++ b/lib/propshaft/compiler.rb
@@ -13,6 +13,10 @@ class Propshaft::Compiler
     raise NotImplementedError
   end
 
+  def find_dependencies(logical_path, input)
+    Set.new
+  end
+
   private
     def url_prefix
       @url_prefix ||= File.join(assembly.config.relative_url_root.to_s, assembly.config.prefix.to_s).chomp("/")

--- a/lib/propshaft/compiler/css_asset_urls.rb
+++ b/lib/propshaft/compiler/css_asset_urls.rb
@@ -9,6 +9,14 @@ class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
     input.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(logical_path.dirname, $1), logical_path, $2, $1 }
   end
 
+  def find_dependencies(logical_path, input)
+    Set.new.tap do |deps|
+      input.scan(ASSET_URL_PATTERN).each do |fn, _|
+        deps << resolve_path(logical_path.dirname, fn)
+      end
+    end
+  end
+
   private
     def resolve_path(directory, filename)
       if filename.start_with?("../")

--- a/lib/propshaft/compilers.rb
+++ b/lib/propshaft/compilers.rb
@@ -30,4 +30,14 @@ class Propshaft::Compilers
       asset.content
     end
   end
+
+  def find_dependencies(asset)
+    Set.new.tap do |deps|
+      if relevant_registrations = registrations[asset.content_type.to_s]
+        relevant_registrations.each do |compiler|
+          deps.merge compiler.new(assembly).find_dependencies(asset.logical_path, asset.content)
+        end
+      end
+    end
+  end
 end

--- a/lib/propshaft/dependency_tree.rb
+++ b/lib/propshaft/dependency_tree.rb
@@ -1,0 +1,61 @@
+class Propshaft::DependencyTree
+
+  def initialize(compilers:)
+    @compilers = compilers
+  end
+
+  # a single pass through the dependent assets, calculating all the dependency
+  # fingerprints we can.
+  def dependency_fingerprint_pass(mapped, dependent_assets)
+    dependent_assets.each do |asset|
+      # the fingerprint can be calculated unless a dependency of this asset
+      # is not ready yet.
+      next if asset.dependencies.detect{|da| da.digest_too_soon?}
+      # ok, ready to set the fingerprint, which is the concatenation of the
+      # digests of each dependent asset.
+      # the fingerprints need to maintain a stable order, done via the sort.
+      asset.dependency_fingerprint = asset.dependencies.map(&:digest).sort.join
+    end
+    # clear out any ones we are done with.
+    dependent_assets.delete_if{|asset| asset.dependency_fingerprint.present?}
+  end
+
+  # After we know the assets that depend on other propshaft assets, we can iterate
+  # through the list, calculating the dependency fingerprint for any asset with
+  # children with known digests.  Once we run out of dependent assets without
+  # digests, we are done.  But if we notice that we aren't making any progress on
+  # an iteration, it means there is an asset dependency cycle.  In that case we
+  # bail out and warn.
+  def set_dependency_fingerprints(mapped, dependent_assets)
+    # There will be N iterations where N is the depth of the longest dependency chain.
+    loop do
+      initial_count = dependent_assets.size
+      dependency_fingerprint_pass(mapped, dependent_assets)
+      break if dependent_assets.empty?    # success, all done
+      if dependent_assets.size == initial_count
+        # failing to make progress
+        cyclic_assets = dependent_assets.map{|a| a.logical_path.to_s}.join(', ')
+        Propshaft.logger.warn "Dependency cycle between #{cyclic_assets}"
+        break
+      end
+    end
+  end
+
+  def traverse(mapped)
+    dependent_assets = Set.new
+    mapped.each_pair do |path, asset|
+      next unless asset.may_depend?     # skip static asset types
+      # get logical paths of dependencies
+      deps = @compilers.find_dependencies(asset)
+      # convert logical paths to asset objects
+      # asset references that aren't managed by propshaft will not be in the mapping
+      # and can be ignored since they won't have digests
+      asset.dependencies = deps.map{|d| mapped[d]}.compact
+      # If no dependencies, the normal digest will be fine for this asset.
+      # Otherwise we will need to perform dependency tree traversal to
+      # create dependency-aware digests. Keep a list of such assets to visit.
+      dependent_assets << asset if asset.dependencies.any?
+    end
+    set_dependency_fingerprints(mapped, dependent_assets)
+  end
+end

--- a/lib/propshaft/dependency_tree.rb
+++ b/lib/propshaft/dependency_tree.rb
@@ -6,7 +6,7 @@ class Propshaft::DependencyTree
 
   # a single pass through the dependent assets, calculating all the dependency
   # fingerprints we can.
-  def dependency_fingerprint_pass(mapped, dependent_assets)
+  def dependency_fingerprint_pass(dependent_assets)
     dependent_assets.each do |asset|
       # the fingerprint can be calculated unless a dependency of this asset
       # is not ready yet.
@@ -26,11 +26,11 @@ class Propshaft::DependencyTree
   # digests, we are done.  But if we notice that we aren't making any progress on
   # an iteration, it means there is an asset dependency cycle.  In that case we
   # bail out and warn.
-  def set_dependency_fingerprints(mapped, dependent_assets)
+  def set_dependency_fingerprints(dependent_assets)
     # There will be N iterations where N is the depth of the longest dependency chain.
     loop do
       initial_count = dependent_assets.size
-      dependency_fingerprint_pass(mapped, dependent_assets)
+      dependency_fingerprint_pass(dependent_assets)
       break if dependent_assets.empty?    # success, all done
       if dependent_assets.size == initial_count
         # failing to make progress
@@ -56,6 +56,6 @@ class Propshaft::DependencyTree
       # create dependency-aware digests. Keep a list of such assets to visit.
       dependent_assets << asset if asset.dependencies.any?
     end
-    set_dependency_fingerprints(mapped, dependent_assets)
+    set_dependency_fingerprints(dependent_assets)
   end
 end

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -3,9 +3,10 @@ require "propshaft/asset"
 class Propshaft::LoadPath
   attr_reader :paths, :version
 
-  def initialize(paths = [], version: nil)
-    @paths   = dedup(paths)
-    @version = version
+  def initialize(paths = [], version: nil, dependency_tree: nil)
+    @paths           = dedup(paths)
+    @version         = version
+    @dependency_tree = dependency_tree
   end
 
   def find(asset_name)
@@ -42,6 +43,11 @@ class Propshaft::LoadPath
     end
   end
 
+  # needed for testing
+  def clear_cache
+    @cached_assets_by_path = nil
+  end
+
   private
     def assets_by_path
       @cached_assets_by_path ||= Hash.new.tap do |mapped|
@@ -51,6 +57,7 @@ class Propshaft::LoadPath
             mapped[logical_path.to_s] ||= Propshaft::Asset.new(file, logical_path: logical_path, version: version)
           end if path.exist?
         end
+        @dependency_tree&.traverse(mapped)
       end
     end
 
@@ -60,10 +67,6 @@ class Propshaft::LoadPath
 
     def without_dotfiles(files)
       files.reject { |file| file.basename.to_s.starts_with?(".") }
-    end
-
-    def clear_cache
-      @cached_assets_by_path = nil
     end
 
     def dedup(paths)

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -43,11 +43,6 @@ class Propshaft::LoadPath
     end
   end
 
-  # needed for testing
-  def clear_cache
-    @cached_assets_by_path = nil
-  end
-
   private
     def assets_by_path
       @cached_assets_by_path ||= Hash.new.tap do |mapped|
@@ -67,6 +62,10 @@ class Propshaft::LoadPath
 
     def without_dotfiles(files)
       files.reject { |file| file.basename.to_s.starts_with?(".") }
+    end
+
+    def clear_cache
+      @cached_assets_by_path = nil
     end
 
     def dedup(paths)

--- a/test/fixtures/assets/dependent/child1.css
+++ b/test/fixtures/assets/dependent/child1.css
@@ -1,0 +1,1 @@
+@import url('child2.css');

--- a/test/fixtures/assets/dependent/child2.css
+++ b/test/fixtures/assets/dependent/child2.css
@@ -1,0 +1,1 @@
+p { background: blue; }

--- a/test/fixtures/assets/dependent/cyclic1.css
+++ b/test/fixtures/assets/dependent/cyclic1.css
@@ -1,0 +1,1 @@
+@import url('cyclic2.css');

--- a/test/fixtures/assets/dependent/cyclic2.css
+++ b/test/fixtures/assets/dependent/cyclic2.css
@@ -1,0 +1,1 @@
+@import url('cyclic1.css');

--- a/test/fixtures/assets/dependent/main.css
+++ b/test/fixtures/assets/dependent/main.css
@@ -1,0 +1,1 @@
+@import url('child1.css');

--- a/test/propshaft/dependency_tree_test.rb
+++ b/test/propshaft/dependency_tree_test.rb
@@ -18,21 +18,23 @@ class Propshaft::DependencyTreeTest < ActiveSupport::TestCase
     @assembly.load_path.assets
   end
 
+  def write_child2(col)
+    File.open("#{__dir__}/../fixtures/assets/dependent/child2.css", "w") do |file|
+      file.puts "p { background: #{col}; }"
+    end
+  end
+
   test "modification of a child affects dependent asset digests" do
+    write_child2('blue')    # ensure no leftovers from previous runs
     prev_assets = @assembly.load_path.assets
     prev_main_digest = prev_assets.detect{|a| a.logical_path.to_s == 'main.css'}.digest
-    File.open("#{__dir__}/../fixtures/assets/dependent/child2.css", "w") do |file|
-      file.puts "p { background: red; }"
-    end
-    @assembly.load_path.clear_cache
+    write_child2('red')
+    @assembly.load_path.cache_sweeper.execute
     changed_assets = @assembly.load_path.assets
     changed_main_digest = changed_assets.detect{|a| a.logical_path.to_s == 'main.css'}.digest
     assert_not_equal(prev_main_digest, changed_main_digest)
-    # restore the original
-    File.open("#{__dir__}/../fixtures/assets/dependent/child2.css", "w") do |file|
-      file.puts "p { background: blue; }"
-    end
-    @assembly.load_path.clear_cache
+    write_child2('blue')    # restore the original
+    @assembly.load_path.cache_sweeper.execute
     final_assets = @assembly.load_path.assets
     final_main_digest = final_assets.detect{|a| a.logical_path.to_s == 'main.css'}.digest
     assert_equal(prev_main_digest, final_main_digest)

--- a/test/propshaft/dependency_tree_test.rb
+++ b/test/propshaft/dependency_tree_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+require "minitest/mock"
+require "propshaft/asset"
+require "propshaft/assembly"
+require "propshaft/compilers"
+
+class Propshaft::DependencyTreeTest < ActiveSupport::TestCase
+  setup do
+    @assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config|
+      config.paths = [ Pathname.new("#{__dir__}/../fixtures/assets/dependent") ]
+      config.output_path = Pathname.new("#{__dir__}/../fixtures/output")
+      config.prefix = "/assets"
+    })
+    @assembly.compilers.register "text/css", Propshaft::Compiler::CssAssetUrls
+  end
+
+  test "cyclic assets do not cause a loop" do
+    @assembly.load_path.assets
+  end
+
+  test "modification of a child affects dependent asset digests" do
+    prev_assets = @assembly.load_path.assets
+    prev_main_digest = prev_assets.detect{|a| a.logical_path.to_s == 'main.css'}.digest
+    File.open("#{__dir__}/../fixtures/assets/dependent/child2.css", "w") do |file|
+      file.puts "p { background: red; }"
+    end
+    @assembly.load_path.clear_cache
+    changed_assets = @assembly.load_path.assets
+    changed_main_digest = changed_assets.detect{|a| a.logical_path.to_s == 'main.css'}.digest
+    assert_not_equal(prev_main_digest, changed_main_digest)
+    # restore the original
+    File.open("#{__dir__}/../fixtures/assets/dependent/child2.css", "w") do |file|
+      file.puts "p { background: blue; }"
+    end
+    @assembly.load_path.clear_cache
+    final_assets = @assembly.load_path.assets
+    final_main_digest = final_assets.detect{|a| a.logical_path.to_s == 'main.css'}.digest
+    assert_equal(prev_main_digest, final_main_digest)
+  end
+end


### PR DESCRIPTION
This PR adds dependency aware asset fingerprinting/digests to address the issue of stale assets remaining in the cache if an indirect dependency changes.  It specifically affects css files with embedded url references, both to image assets and in @import statements.  Js files use the import-map mechanism which avoids the need for any changes there.

The basic idea is to extract the dependencies using the css asset url compiler that updates them in the first place.  This is done after the load_path assets_by_path method creates all the asset objects.  A new DependencyTree class gets invoked to handle any assets with dependencies in an ordered fashion that will create stable digests that incorporate dependency fingerprint information.

Here is a walkthrough of the individual class changes.

**Asset**
- new accessors for dependencies and dependency_fingerprint.  These are set by DependencyTree once all of the assets in the LoadPath are known.  Dependencies will be nil if the asset type does not support dependencies.  Otherwise, it will be a Set of the logical paths of the detected dependencies.  The dependency_fingerprint is set once the dependencies of this asset have known digests.  It is the concatenation of the sorted digests of the dependencies.
- a may_depend? method to quicky skip asset types that don't have dependencies (non-css).
- a digest_to_soon? method that helps DependencyTree decide if this asset is ready to have its dependency_fingerprint set.  It is also used to warn if we wind up calculating a digest before the dependency information is ready.  In theory, this shouldn't happen.
- the digest method now concatenates the dependency_fingerprint with the content and version, so that the digest will change appropriately as depdendencies change.  Note that we don't need to digest the compiled content if we include a fingerprint that varies when any dependent file changes.

**Compiler**
- adds a new find_dependencies action which should return a Set of the logical paths of the assets this asset depends on.  Defaults to empty.

**Compilers**
- supports find_dependencies by merging the find_dependencies results from each relevant compiler.

**CssAssetUrls**
- uses the existing regex to slice out the dependent assets that will have their digests added.

**Assembly**
- adds a dependency_tree method to instantiate the DependencyTree, passing the compilers.
- modifies the creation of LoadPath to take a dependency tree.

**LoadPath**
- take a DependencyTree object when initialized.
- moved the clear_cache method to public so that it can be used to test that digests change appropriately.
- in assets_by_path, once all the Asset objects have been created, call dependency_tree#traverse on them to resolve dependent digests.

**DependencyTree**
- this is a new class that implements the bottom up tree traversal to calculate the dependency fingerprints. For each asset, if it could have dependencies, and if there is at least one asset known to propshaft that it depends on, keep it in our list of assets to process.
- set_dependency_fingerprints processes these assets. We iterate through the list, calculating the dependency fingerprint for any asset with children with known digests.  In the first loop these will be the "leaf" assets that only depend on static assets like images.  On the next loop, it will be the assets that only depend on "leaf" assets, and so on. Once we run out of dependent assets without digests, we are done.  But if we notice that we aren't making any progress on an iteration, it means there is an asset dependency cycle.  In that case we bail out and warn.

Fixes https://github.com/rails/propshaft/issues/123 and https://github.com/rails/propshaft/issues/90