### PR TITLE
Preserve options with `stylesheet_link_tag` `:all`

### DIFF
--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -5,9 +5,9 @@ module Propshaft
     end
 
     # Add an option to call `stylesheet_link_tag` with `:all` to include every css file found on the load path.
-    def stylesheet_link_tag(*sources)
+    def stylesheet_link_tag(*sources, **options)
       if sources.first == :all
-        super *all_stylesheets_paths
+        super *all_stylesheets_paths, **options
       else
         super
       end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag :all %>
+    <%= stylesheet_link_tag :all, data: { custom_attribute: true } %>
   </head>
 
   <body>

--- a/test/propshaft_integration_test.rb
+++ b/test/propshaft_integration_test.rb
@@ -6,8 +6,8 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    assert_select 'link[href="/assets/hello_world-4137140a.css"]'
-    assert_select 'link[href="/assets/goodbye-b1dc9940.css"]'
+    assert_select 'link[href="/assets/hello_world-4137140a.css"][data-custom-attribute="true"]'
+    assert_select 'link[href="/assets/goodbye-b1dc9940.css"][data-custom-attribute="true"]'
 
     assert_select 'script[src="/assets/hello_world-888761f8.js"]'
   end


### PR DESCRIPTION
Ensure that we don't lose any options passed to `stylesheet_link_tag` when using the `:all` option.

Previously the kwargs were being discarded, which breaks common use cases like:

```ruby
stylesheet_link_tag :all, "data-turbo-track": "reload"
```

/cc @dhh