### PR TITLE
Fixed helper splat warning due to being interpreted as argument prefix

### DIFF
--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -7,7 +7,7 @@ module Propshaft
     # Add an option to call `stylesheet_link_tag` with `:all` to include every css file found on the load path.
     def stylesheet_link_tag(*sources, **options)
       if sources.first == :all
-        super *all_stylesheets_paths, **options
+        super(*all_stylesheets_paths, **options)
       else
         super
       end


### PR DESCRIPTION
## Overview

Hello. :wave: Was seeing warnings show up in my test suite, since I have Ruby warnings enabled, and wanted to fix the issue in in this gem.

## Details

Necessary to resolve the following warnings showing up when using this gem in test suites with Ruby warnings enabled (i.e. `ruby -w`): `gems/propshaft-0.8.0/lib/propshaft/helper.rb:10: warning: *' interpreted as argument prefix`. By using parenthesis, these warnings go away and the test suite output is much cleaner.

## Notes

Not sure when you plan to publish a new version of this gem but if a patch release is acceptable, that would be most welcome. :bow: