### PR TITLE
Add an option to only pick assets from app/assets/stylesheets using stylesheet_link_tag :app

### DIFF
--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -4,22 +4,40 @@ module Propshaft
       Rails.application.assets.resolver.resolve(path) || raise(MissingAssetError.new(path))
     end
 
-    # Add an option to call `stylesheet_link_tag` with `:all` to include every css file found on the load path.
+    # Add an option to call `stylesheet_link_tag` with
+    # `:all` to include every css file found on the load path or
+    # `:app` to include every css file found on `app/assets/stylesheets`.
     def stylesheet_link_tag(*sources, **options)
-      if sources.first == :all
+      case sources.first
+      when :all
         super(*all_stylesheets_paths, **options)
+      when :app
+        super(*app_stylesheets_paths, **options)
       else
         super
       end
     end
 
-    # Returns a sorted and unique array of logical paths for all stylesheets in the load path.
-    def all_stylesheets_paths
-      Rails.application.assets.load_path
-        .assets(content_types: [ Mime::EXTENSION_LOOKUP["css"] ])
-        .collect { |css| css.logical_path.to_s }
-        .sort
-        .uniq
-    end
+    private
+      def all_stylesheets_paths
+        stylesheets_paths_for(Rails.application.assets.load_path)
+      end
+
+      def app_stylesheets_paths
+        stylesheets_paths_for(
+          Rails.application.assets.load_path.dup.tap do |load_path|
+            load_path.paths = [ Rails.root.join("app/assets/stylesheets") ]
+          end
+        )
+      end
+
+      # Returns a sorted and unique array of logical paths for a stylesheets load path.
+      def stylesheets_paths_for(load_path)
+        load_path
+          .assets(content_types: [ Mime::EXTENSION_LOOKUP["css"] ])
+          .collect { |css| css.logical_path.to_s }
+          .sort
+          .uniq
+      end
   end
 end

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -7,6 +7,11 @@ class Propshaft::LoadPath
     @paths, @compilers, @version = dedup(paths), compilers, version
   end
 
+  def paths=(paths)
+    @paths = dedup(paths)
+    clear_cache
+  end
+
   def find(asset_name)
     assets_by_path[asset_name]
   end

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -1,0 +1,5 @@
+module ApplicationHelper
+  def app_stylesheets?
+    params[:stylesheets] == "app"
+  end
+end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag :all, data: { custom_attribute: true } %>
+    <%= stylesheet_link_tag(app_stylesheets? ? :app : :all, data: { custom_attribute: true }) %>
   </head>
 
   <body>

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -31,5 +31,6 @@ module Dummy
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.assets.paths << File.join(Rails.root, "vendor", "stylesheets")
   end
 end

--- a/test/propshaft_integration_test.rb
+++ b/test/propshaft_integration_test.rb
@@ -8,8 +8,18 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_select 'link[href="/assets/hello_world-4137140a.css"][data-custom-attribute="true"]'
     assert_select 'link[href="/assets/goodbye-b1dc9940.css"][data-custom-attribute="true"]'
+    assert_select 'link[href="/assets/library-356a192b.css"][data-custom-attribute="true"]'
 
     assert_select 'script[src="/assets/hello_world-888761f8.js"]'
+  end
+
+  test "using stylesheet_link_tag :app option should only resolve assets contained in app/assets/stylesheets" do
+    get sample_load_real_assets_url(stylesheets: :app)
+
+    assert_response :success
+    assert_select 'link[href="/assets/hello_world-4137140a.css"][data-custom-attribute="true"]'
+    assert_select 'link[href="/assets/goodbye-b1dc9940.css"][data-custom-attribute="true"]'
+    assert_select 'link[href="/assets/library-356a192b.css"][data-custom-attribute="true"]', 0
   end
 
   test "should raise an exception when resolving nonexistent assets" do


### PR DESCRIPTION
This is a simple proof of concept to resolve the issue raised in [this comment](https://github.com/rails/rails/pull/51799#discussion_r1601955873).

The idea is that when using the helper it only includes the CSS files contained in the `app/assets/stylesheets` folder. This way, no external CSS styles will be included in the application, for example from engines like Mission Control.

Obviously, this could break applications that are using this and assume that they include all CSS files from all engines automatically, such as Trix. They would have to be included manually.

I see this as an intermediate option between including all CSS files from the load path or not including any and using `@import` manually for each file.