### PR TITLE
Digests of files that can have dependencies on other files in the load path need to reflect those dependencies

### DIFF
--- a/benchmarks/css_asset_urls
+++ b/benchmarks/css_asset_urls
@@ -25,5 +25,5 @@ compiler = Propshaft::Compiler::CssAssetUrls.new(assembly)
 
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
-  x.report("compile") { compiler.compile(asset.logical_path, asset.content) }
+  x.report("compile") { compiler.compile(asset, asset.content) }
 end

--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -15,7 +15,7 @@ class Propshaft::Assembly
   end
 
   def load_path
-    @load_path ||= Propshaft::LoadPath.new(config.paths, version: config.version)
+    @load_path ||= Propshaft::LoadPath.new(config.paths, compilers: compilers, version: config.version)
   end
 
   def resolver

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -21,7 +21,7 @@ class Propshaft::Asset
   end
 
   def digest
-    @digest ||= Digest::SHA1.hexdigest("#{content_with_compile_dependencies}#{load_path.version}").first(8)
+    @digest ||= Digest::SHA1.hexdigest("#{content_with_compile_references}#{load_path.version}").first(8)
   end
 
   def digested_path
@@ -41,7 +41,7 @@ class Propshaft::Asset
   end
 
   private
-    def content_with_compile_dependencies
+    def content_with_compile_references
       content + load_path.find_references_by(self).collect(&:content).join
     end
 

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -42,7 +42,7 @@ class Propshaft::Asset
 
   private
     def content_with_compile_references
-      content + load_path.find_references_by(self).collect(&:content).join
+      content + load_path.find_referenced_by(self).collect(&:content).join
     end
 
     def already_digested?

--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -41,11 +41,11 @@ class Propshaft::Asset
   end
 
   private
-    def already_digested?
-      logical_path.to_s =~ /-([0-9a-zA-Z_-]{7,128})\.digested/
+    def content_with_compile_dependencies
+      content + load_path.find_references_by(self).collect(&:content).join
     end
 
-    def content_with_compile_dependencies
-      content + load_path.find_compiler_dependencies_to(self).collect(&:content).join
+    def already_digested?
+      logical_path.to_s =~ /-([0-9a-zA-Z_-]{7,128})\.digested/
     end
 end

--- a/lib/propshaft/compiler.rb
+++ b/lib/propshaft/compiler.rb
@@ -9,8 +9,12 @@ class Propshaft::Compiler
   end
 
   # Override this in a specific compiler
-  def compile(logical_path, input)
+  def compile(asset)
     raise NotImplementedError
+  end
+
+  def find_dependencies(asset)
+    Set.new
   end
 
   private

--- a/lib/propshaft/compiler.rb
+++ b/lib/propshaft/compiler.rb
@@ -13,7 +13,7 @@ class Propshaft::Compiler
     raise NotImplementedError
   end
 
-  def find_dependencies(asset)
+  def referenced_by(asset)
     Set.new
   end
 

--- a/lib/propshaft/compiler.rb
+++ b/lib/propshaft/compiler.rb
@@ -3,6 +3,7 @@
 # Base compiler from which other compilers can inherit
 class Propshaft::Compiler
   attr_reader :assembly
+  delegate :config, :load_path, to: :assembly
 
   def initialize(assembly)
     @assembly = assembly
@@ -19,6 +20,6 @@ class Propshaft::Compiler
 
   private
     def url_prefix
-      @url_prefix ||= File.join(assembly.config.relative_url_root.to_s, assembly.config.prefix.to_s).chomp("/")
+      @url_prefix ||= File.join(config.relative_url_root.to_s, config.prefix.to_s).chomp("/")
     end
 end

--- a/lib/propshaft/compiler.rb
+++ b/lib/propshaft/compiler.rb
@@ -10,7 +10,7 @@ class Propshaft::Compiler
   end
 
   # Override this in a specific compiler
-  def compile(asset)
+  def compile(asset, input)
     raise NotImplementedError
   end
 

--- a/lib/propshaft/compiler/css_asset_urls.rb
+++ b/lib/propshaft/compiler/css_asset_urls.rb
@@ -14,7 +14,7 @@ class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
       asset.content.scan(ASSET_URL_PATTERN).each do |referenced_asset_url, _|
         referenced_asset = load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
 
-        if references.exclude?(referenced_asset)
+        unless references.include?(referenced_asset)
           references << referenced_asset
           references.merge referenced_by(referenced_asset)
         end

--- a/lib/propshaft/compiler/css_asset_urls.rb
+++ b/lib/propshaft/compiler/css_asset_urls.rb
@@ -13,7 +13,7 @@ class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
     asset.content.scan(ASSET_URL_PATTERN).each do |referenced_asset_url, _|
       referenced_asset = load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
 
-      unless references.include?(referenced_asset)
+      if referenced_asset && references.exclude?(referenced_asset)
         references << referenced_asset
         references.merge referenced_by(referenced_asset, references: references)
       end

--- a/lib/propshaft/compiler/css_asset_urls.rb
+++ b/lib/propshaft/compiler/css_asset_urls.rb
@@ -9,14 +9,14 @@ class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
     asset.content.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(asset.logical_path.dirname, $1), asset.logical_path, $2, $1 }
   end
 
-  def find_dependencies(asset)
-    Set.new.tap do |dependencies|
-      asset.content.scan(ASSET_URL_PATTERN).each do |dependent_asset_url, _|
-        dependent_asset = assembly.load_path.find(resolve_path(asset.logical_path.dirname, dependent_asset_url))
+  def referenced_by(asset)
+    Set.new.tap do |references|
+      asset.content.scan(ASSET_URL_PATTERN).each do |referenced_asset_url, _|
+        referenced_asset = assembly.load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
 
-        if dependencies.exclude?(dependent_asset)
-          dependencies << dependent_asset
-          dependencies.merge(find_dependencies(dependent_asset))
+        if references.exclude?(referenced_asset)
+          references << referenced_asset
+          references.merge referenced_by(referenced_asset)
         end
       end
     end

--- a/lib/propshaft/compiler/css_asset_urls.rb
+++ b/lib/propshaft/compiler/css_asset_urls.rb
@@ -9,17 +9,17 @@ class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
     input.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(asset.logical_path.dirname, $1), asset.logical_path, $2, $1 }
   end
 
-  def referenced_by(asset)
-    Set.new.tap do |references|
-      asset.content.scan(ASSET_URL_PATTERN).each do |referenced_asset_url, _|
-        referenced_asset = load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
+  def referenced_by(asset, references: Set.new)
+    asset.content.scan(ASSET_URL_PATTERN).each do |referenced_asset_url, _|
+      referenced_asset = load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
 
-        unless references.include?(referenced_asset)
-          references << referenced_asset
-          references.merge referenced_by(referenced_asset)
-        end
+      unless references.include?(referenced_asset)
+        references << referenced_asset
+        references.merge referenced_by(referenced_asset, references: references)
       end
     end
+
+    references
   end
 
   private

--- a/lib/propshaft/compiler/css_asset_urls.rb
+++ b/lib/propshaft/compiler/css_asset_urls.rb
@@ -5,8 +5,8 @@ require "propshaft/compiler"
 class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
   ASSET_URL_PATTERN = /url\(\s*["']?(?!(?:\#|%23|data|http|\/\/))([^"'\s?#)]+)([#?][^"')]+)?\s*["']?\)/
 
-  def compile(asset)
-    asset.content.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(asset.logical_path.dirname, $1), asset.logical_path, $2, $1 }
+  def compile(asset, input)
+    input.gsub(ASSET_URL_PATTERN) { asset_url resolve_path(asset.logical_path.dirname, $1), asset.logical_path, $2, $1 }
   end
 
   def referenced_by(asset)

--- a/lib/propshaft/compiler/css_asset_urls.rb
+++ b/lib/propshaft/compiler/css_asset_urls.rb
@@ -12,7 +12,7 @@ class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
   def referenced_by(asset)
     Set.new.tap do |references|
       asset.content.scan(ASSET_URL_PATTERN).each do |referenced_asset_url, _|
-        referenced_asset = assembly.load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
+        referenced_asset = load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
 
         if references.exclude?(referenced_asset)
           references << referenced_asset
@@ -34,7 +34,7 @@ class Propshaft::Compiler::CssAssetUrls < Propshaft::Compiler
     end
 
     def asset_url(resolved_path, logical_path, fingerprint, pattern)
-      if asset = assembly.load_path.find(resolved_path)
+      if asset = load_path.find(resolved_path)
         %[url("#{url_prefix}/#{asset.digested_path}#{fingerprint}")]
       else
         Propshaft.logger.warn "Unable to resolve '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}"

--- a/lib/propshaft/compiler/source_mapping_urls.rb
+++ b/lib/propshaft/compiler/source_mapping_urls.rb
@@ -21,7 +21,7 @@ class Propshaft::Compiler::SourceMappingUrls < Propshaft::Compiler
     end
 
     def source_mapping_url(logical_path, resolved_path, comment_start, comment_end)
-      if asset = assembly.load_path.find(resolved_path)
+      if asset = load_path.find(resolved_path)
         "#{comment_start}# sourceMappingURL=#{url_prefix}/#{asset.digested_path}#{comment_end}"
       else
         Propshaft.logger.warn "Removed sourceMappingURL comment for missing asset '#{resolved_path}' from #{logical_path}"

--- a/lib/propshaft/compiler/source_mapping_urls.rb
+++ b/lib/propshaft/compiler/source_mapping_urls.rb
@@ -5,8 +5,8 @@ require "propshaft/compiler"
 class Propshaft::Compiler::SourceMappingUrls < Propshaft::Compiler
   SOURCE_MAPPING_PATTERN = %r{(//|/\*)# sourceMappingURL=(.+\.map)(\s*?\*\/)?\s*?\Z}
 
-  def compile(asset)
-    asset.content.gsub(SOURCE_MAPPING_PATTERN) { source_mapping_url(asset.logical_path, asset_path($2, asset.logical_path), $1, $3) }
+  def compile(asset, input)
+    input.gsub(SOURCE_MAPPING_PATTERN) { source_mapping_url(asset.logical_path, asset_path($2, asset.logical_path), $1, $3) }
   end
 
   private

--- a/lib/propshaft/compiler/source_mapping_urls.rb
+++ b/lib/propshaft/compiler/source_mapping_urls.rb
@@ -5,8 +5,8 @@ require "propshaft/compiler"
 class Propshaft::Compiler::SourceMappingUrls < Propshaft::Compiler
   SOURCE_MAPPING_PATTERN = %r{(//|/\*)# sourceMappingURL=(.+\.map)(\s*?\*\/)?\s*?\Z}
 
-  def compile(logical_path, input)
-    input.gsub(SOURCE_MAPPING_PATTERN) { source_mapping_url(logical_path, asset_path($2, logical_path), $1, $3) }
+  def compile(asset)
+    asset.content.gsub(SOURCE_MAPPING_PATTERN) { source_mapping_url(asset.logical_path, asset_path($2, asset.logical_path), $1, $3) }
   end
 
   private

--- a/lib/propshaft/compilers.rb
+++ b/lib/propshaft/compilers.rb
@@ -23,7 +23,7 @@ class Propshaft::Compilers
     if relevant_registrations = registrations[asset.content_type.to_s]
       asset.content.dup.tap do |input|
         relevant_registrations.each do |compiler|
-          input.replace compiler.new(assembly).compile(asset)
+          input.replace compiler.new(assembly).compile(asset, input)
         end
       end
     else

--- a/lib/propshaft/compilers.rb
+++ b/lib/propshaft/compilers.rb
@@ -31,11 +31,11 @@ class Propshaft::Compilers
     end
   end
 
-  def find_dependencies(asset)
-    Set.new.tap do |dependencies|
+  def referenced_by(asset)
+    Set.new.tap do |references|
       if relevant_registrations = registrations[asset.content_type.to_s]
         relevant_registrations.each do |compiler|
-          dependencies.merge compiler.new(assembly).find_dependencies(asset)
+          references.merge compiler.new(assembly).referenced_by(asset)
         end
       end
     end

--- a/lib/propshaft/compilers.rb
+++ b/lib/propshaft/compilers.rb
@@ -23,11 +23,21 @@ class Propshaft::Compilers
     if relevant_registrations = registrations[asset.content_type.to_s]
       asset.content.dup.tap do |input|
         relevant_registrations.each do |compiler|
-          input.replace compiler.new(assembly).compile(asset.logical_path, input)
+          input.replace compiler.new(assembly).compile(asset)
         end
       end
     else
       asset.content
+    end
+  end
+
+  def find_dependencies(asset)
+    Set.new.tap do |dependencies|
+      if relevant_registrations = registrations[asset.content_type.to_s]
+        relevant_registrations.each do |compiler|
+          dependencies.merge compiler.new(assembly).find_dependencies(asset)
+        end
+      end
     end
   end
 end

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -11,8 +11,8 @@ class Propshaft::LoadPath
     assets_by_path[asset_name]
   end
 
-  def find_compiler_dependencies_to(asset)
-    compilers&.find_dependencies(asset) || Set.new
+  def find_references_by(asset)
+    compilers&.referenced_by(asset) || Set.new
   end
 
   def assets(content_types: nil)

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -3,7 +3,7 @@ require "propshaft/asset"
 class Propshaft::LoadPath
   attr_reader :paths, :compilers, :version
 
-  def initialize(paths = [], compilers: nil, version: nil)
+  def initialize(paths = [], compilers:, version: nil)
     @paths, @compilers, @version = dedup(paths), compilers, version
   end
 
@@ -12,7 +12,7 @@ class Propshaft::LoadPath
   end
 
   def find_references_by(asset)
-    compilers&.referenced_by(asset) || Set.new
+    compilers.referenced_by(asset) || Set.new
   end
 
   def assets(content_types: nil)

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -12,7 +12,7 @@ class Propshaft::LoadPath
   end
 
   def find_referenced_by(asset)
-    compilers.referenced_by(asset)
+    compilers.referenced_by(asset).delete(self)
   end
 
   def assets(content_types: nil)

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -11,7 +11,7 @@ class Propshaft::LoadPath
     assets_by_path[asset_name]
   end
 
-  def find_references_by(asset)
+  def find_referenced_by(asset)
     compilers.referenced_by(asset)
   end
 

--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -12,7 +12,7 @@ class Propshaft::LoadPath
   end
 
   def find_references_by(asset)
-    compilers.referenced_by(asset) || Set.new
+    compilers.referenced_by(asset)
   end
 
   def assets(content_types: nil)

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/fixtures/assets/first_path/dependent/a.css
+++ b/test/fixtures/assets/first_path/dependent/a.css
@@ -1,0 +1,1 @@
+@import url('b.css')

--- a/test/fixtures/assets/first_path/dependent/b.css
+++ b/test/fixtures/assets/first_path/dependent/b.css
@@ -1,1 +1,2 @@
 @import url('c.css')
+@import url('missing.css')

--- a/test/fixtures/assets/first_path/dependent/b.css
+++ b/test/fixtures/assets/first_path/dependent/b.css
@@ -1,0 +1,1 @@
+@import url('c.css')

--- a/test/fixtures/assets/first_path/dependent/c.css
+++ b/test/fixtures/assets/first_path/dependent/c.css
@@ -1,0 +1,3 @@
+p {
+  color: red;
+}

--- a/test/fixtures/assets/first_path/dependent/c.css
+++ b/test/fixtures/assets/first_path/dependent/c.css
@@ -1,3 +1,5 @@
+@import url('a.css')
+
 p {
   color: red;
 }

--- a/test/propshaft/compiler/css_asset_urls_test.rb
+++ b/test/propshaft/compiler/css_asset_urls_test.rb
@@ -130,10 +130,11 @@ class Propshaft::Compiler::CssAssetUrlsTest < ActiveSupport::TestCase
       root_path    = Pathname.new("#{__dir__}/../../fixtures/assets/vendor")
       logical_path = "foobar/source/test.css"
 
-      asset     = Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path)
+      assembly = Propshaft::Assembly.new(@options)
+      assembly.compilers.register "text/css", Propshaft::Compiler::CssAssetUrls
+
+      asset     = Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: assembly.load_path)
       asset.stub :content, content do
-        assembly = Propshaft::Assembly.new(@options)
-        assembly.compilers.register "text/css", Propshaft::Compiler::CssAssetUrls
         assembly.compilers.compile(asset)
       end
     end

--- a/test/propshaft/compilers_test.rb
+++ b/test/propshaft/compilers_test.rb
@@ -20,6 +20,7 @@ class Propshaft::CompilersTest < ActiveSupport::TestCase
   private
     def find_asset(logical_path)
       root_path = Pathname.new("#{__dir__}/../fixtures/assets/first_path")
-      Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: Propshaft::LoadPath.new([ root_path ]))
+      load_path = Propshaft::LoadPath.new([ root_path ], compilers: Propshaft::Compilers.new(nil))
+      Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: load_path)
     end
 end

--- a/test/propshaft/compilers_test.rb
+++ b/test/propshaft/compilers_test.rb
@@ -20,6 +20,6 @@ class Propshaft::CompilersTest < ActiveSupport::TestCase
   private
     def find_asset(logical_path)
       root_path = Pathname.new("#{__dir__}/../fixtures/assets/first_path")
-      Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path)
+      Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: Propshaft::LoadPath.new([ root_path ]))
     end
 end

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -72,9 +72,7 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
 
   private
     def find_asset(logical_path)
-      Propshaft::Asset.new(
-        Pathname.new("#{__dir__}/../fixtures/assets/first_path/#{logical_path}"),
-        logical_path: Pathname.new(logical_path)
-      )
+      root_path = Pathname.new("#{__dir__}/../fixtures/assets/first_path")
+      Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: Propshaft::LoadPath.new([ root_path ]))
     end
 end

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -6,7 +6,7 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     @load_path = Propshaft::LoadPath.new [
       Pathname.new("#{__dir__}/../fixtures/assets/first_path"),
       Pathname.new("#{__dir__}/../fixtures/assets/second_path").to_s
-    ]
+    ], compilers: Propshaft::Compilers.new(nil)
   end
 
   test "find asset that only appears once in the paths" do
@@ -44,7 +44,7 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
   end
 
   test "manifest with version" do
-    @load_path = Propshaft::LoadPath.new(@load_path.paths, version: "1")
+    @load_path = Propshaft::LoadPath.new(@load_path.paths, version: "1", compilers: Propshaft::Compilers.new(nil))
     @load_path.manifest.tap do |manifest|
       assert_equal "one-c9373b68.txt", manifest["one.txt"]
       assert_equal "nested/three-a41a5d38.txt", manifest["nested/three.txt"]
@@ -52,7 +52,7 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
   end
 
   test "missing load path directory" do
-    assert_nil Propshaft::LoadPath.new(Pathname.new("#{__dir__}/../fixtures/assets/nowhere")).find("missing")
+    assert_nil Propshaft::LoadPath.new(Pathname.new("#{__dir__}/../fixtures/assets/nowhere"), compilers: Propshaft::Compilers.new(nil)).find("missing")
   end
 
   test "deduplicate paths" do
@@ -62,7 +62,7 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
       "app/assets/stylesheets",
       "app/assets/images",
       "app/assets"
-    ]
+    ], compilers: Propshaft::Compilers.new(nil)
 
     paths = load_path.paths
     assert_equal 2, paths.count
@@ -73,6 +73,7 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
   private
     def find_asset(logical_path)
       root_path = Pathname.new("#{__dir__}/../fixtures/assets/first_path")
-      Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: Propshaft::LoadPath.new([ root_path ]))
+      load_path = Propshaft::LoadPath.new([ root_path ], compilers: Propshaft::Compilers.new(nil))
+      Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: load_path)
     end
 end

--- a/test/propshaft/output_path_test.rb
+++ b/test/propshaft/output_path_test.rb
@@ -64,7 +64,7 @@ class Propshaft::OutputPathTest < ActiveSupport::TestCase
 
   private
     def output_asset(filename, content, created_at: Time.now)
-      asset = Propshaft::Asset.new(nil, logical_path: filename)
+      asset = Propshaft::Asset.new(nil, logical_path: filename, load_path: Propshaft::LoadPath.new)
       asset.stub :content, content do
         output_path = @output_path.path.join(asset.digested_path)
         `touch -mt #{created_at.strftime('%y%m%d%H%M')} #{output_path}`

--- a/test/propshaft/output_path_test.rb
+++ b/test/propshaft/output_path_test.rb
@@ -64,7 +64,8 @@ class Propshaft::OutputPathTest < ActiveSupport::TestCase
 
   private
     def output_asset(filename, content, created_at: Time.now)
-      asset = Propshaft::Asset.new(nil, logical_path: filename, load_path: Propshaft::LoadPath.new)
+      load_path = Propshaft::LoadPath.new([], compilers: Propshaft::Compilers.new(nil))
+      asset = Propshaft::Asset.new(nil, logical_path: filename, load_path: load_path)
       asset.stub :content, content do
         output_path = @output_path.path.join(asset.digested_path)
         `touch -mt #{created_at.strftime('%y%m%d%H%M')} #{output_path}`

--- a/test/propshaft/resolver/dynamic_test.rb
+++ b/test/propshaft/resolver/dynamic_test.rb
@@ -3,7 +3,7 @@ require "propshaft/resolver/dynamic"
 
 class Propshaft::Resolver::DynamicTest < ActiveSupport::TestCase
   setup do
-    @load_path = Propshaft::LoadPath.new Pathname.new("#{__dir__}/../../fixtures/assets/first_path")
+    @load_path = Propshaft::LoadPath.new Pathname.new("#{__dir__}/../../fixtures/assets/first_path"), compilers: Propshaft::Compilers.new(nil)
     @resolver  = Propshaft::Resolver::Dynamic.new(load_path: @load_path, prefix: "/assets")
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,6 @@ class ActiveSupport::TestCase
     def find_asset(logical_path, fixture_path:)
       root_path = Pathname.new("#{__dir__}/fixtures/assets/#{fixture_path}")
       path = root_path.join(logical_path)
-      Propshaft::Asset.new(path, logical_path: logical_path)
+      Propshaft::Asset.new(path, logical_path: logical_path, load_path: Propshaft::LoadPath.new([ root_path ]))
     end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,8 @@ class ActiveSupport::TestCase
     def find_asset(logical_path, fixture_path:)
       root_path = Pathname.new("#{__dir__}/fixtures/assets/#{fixture_path}")
       path = root_path.join(logical_path)
-      Propshaft::Asset.new(path, logical_path: logical_path, load_path: Propshaft::LoadPath.new([ root_path ]))
+      load_path = Propshaft::LoadPath.new([ root_path ], compilers: Propshaft::Compilers.new(nil))
+
+      Propshaft::Asset.new(path, logical_path: logical_path, load_path: load_path)
     end
 end


### PR DESCRIPTION
CSS files that reference other CSS files via `@import` or images via `url()` need to have their digest reflect changes in the dependencies. This PR adds that by including the content of all dependencies in the calculation for such assets with dependencies.

This takes some inspiration from https://github.com/rails/propshaft/pull/175 but avoids the dependency tree tracking.