### PR TITLE
Provide :all and :app helpers for stylesheet references via cached methods

### DIFF
--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -6,8 +6,11 @@ module Propshaft
 
     # Add an option to call `stylesheet_link_tag` with `:all` to include every css file found on the load path.
     def stylesheet_link_tag(*sources, **options)
-      if sources.first == :all
-        super(*all_stylesheets_paths, **options)
+      case sources.first
+      when :all
+        super(*all_stylesheets_paths , **options)
+      when :app
+        super(*app_stylesheets_paths , **options)
       else
         super
       end
@@ -15,11 +18,12 @@ module Propshaft
 
     # Returns a sorted and unique array of logical paths for all stylesheets in the load path.
     def all_stylesheets_paths
-      Rails.application.assets.load_path
-        .assets(content_types: [ Mime::EXTENSION_LOOKUP["css"] ])
-        .collect { |css| css.logical_path.to_s }
-        .sort
-        .uniq
+      Rails.application.assets.load_path.asset_paths_by_type("css")
+    end
+
+    # Returns a sorted and unique array of logical paths for all stylesheets in app/assets/stylesheets.
+    def app_stylesheets_path
+      Rails.application.assets.load_path.assets_path_by_glob("**/app/assets/stylesheets/**/*.css")
     end
   end
 end

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -23,7 +23,7 @@ module Propshaft
 
     # Returns a sorted and unique array of logical paths for all stylesheets in app/assets/**/*.css.
     def app_stylesheets_paths
-      Rails.application.assets.load_path.asset_paths_by_glob("**/app/assets/**/*.css")
+      Rails.application.assets.load_path.asset_paths_by_glob("#{Rails.root.join("app/assets")}/**/*.css")
     end
   end
 end

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -21,9 +21,9 @@ module Propshaft
       Rails.application.assets.load_path.asset_paths_by_type("css")
     end
 
-    # Returns a sorted and unique array of logical paths for all stylesheets in app/assets/stylesheets.
-    def app_stylesheets_path
-      Rails.application.assets.load_path.assets_path_by_glob("**/app/assets/stylesheets/**/*.css")
+    # Returns a sorted and unique array of logical paths for all stylesheets in app/assets/**/*.css.
+    def app_stylesheets_paths
+      Rails.application.assets.load_path.asset_paths_by_glob("**/app/assets/**/*.css")
     end
   end
 end

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -4,7 +4,8 @@ module Propshaft
       Rails.application.assets.resolver.resolve(path) || raise(MissingAssetError.new(path))
     end
 
-    # Add an option to call `stylesheet_link_tag` with `:all` to include every css file found on the load path.
+    # Add an option to call `stylesheet_link_tag` with `:all` to include every css file found on the load path
+    # or `:app` to include css files found in `Rails.root("app/assets/**/*.css")`, which will exclude lib/ and plugins.
     def stylesheet_link_tag(*sources, **options)
       case sources.first
       when :all

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag :all, data: { custom_attribute: true } %>
+    <%= stylesheet_link_tag :app, data: { glob_attribute: true } %>
   </head>
 
   <body>

--- a/test/dummy/lib/assets/stylesheets/library.css
+++ b/test/dummy/lib/assets/stylesheets/library.css
@@ -1,0 +1,1 @@
+# Library css that should not be included by :app but should be included by :all

--- a/test/propshaft/load_path_test.rb
+++ b/test/propshaft/load_path_test.rb
@@ -29,13 +29,6 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     assert_not_includes @load_path.assets, find_asset(".stuff")
   end
 
-  test "assets by given content types" do
-    assert_not_includes @load_path.assets(content_types: [ Mime[:js] ]), find_asset("one.txt")
-    assert_includes @load_path.assets(content_types: [ Mime[:js] ]), find_asset("again.js")
-    assert_includes @load_path.assets(content_types: [ Mime[:js], Mime[:css] ]), find_asset("again.js")
-    assert_includes @load_path.assets(content_types: [ Mime[:js], Mime[:css] ]), find_asset("another.css")
-  end
-
   test "manifest" do
     @load_path.manifest.tap do |manifest|
       assert_equal "one-f2e1ec14.txt", manifest["one.txt"]
@@ -68,6 +61,18 @@ class Propshaft::LoadPathTest < ActiveSupport::TestCase
     assert_equal 2, paths.count
     assert_equal Pathname.new("app/javascript"), paths.first
     assert_equal Pathname.new("app/assets"), paths.last
+  end
+
+  test "asset paths by type" do
+    assert_equal \
+      ["another.css", "dependent/a.css", "dependent/b.css", "dependent/c.css", "file-already-abcdefVWXYZ0123456789_-.digested.css", "file-already-abcdefVWXYZ0123456789_-.digested.debug.css", "file-not.digested.css"],
+      @load_path.asset_paths_by_type("css")
+  end
+
+  test "asset paths by glob" do
+    assert_equal \
+      ["dependent/a.css", "dependent/b.css", "dependent/c.css"],
+      @load_path.asset_paths_by_glob("**/dependent/*.css")
   end
 
   private

--- a/test/propshaft_integration_test.rb
+++ b/test/propshaft_integration_test.rb
@@ -12,6 +12,13 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'script[src="/assets/hello_world-888761f8.js"]'
   end
 
+  test "should find app styles via glob" do
+    get sample_load_real_assets_url
+
+    assert_select 'link[href="/assets/hello_world-4137140a.css"][data-glob-attribute="true"]'
+    assert_select 'link[href="/assets/goodbye-b1dc9940.css"][data-glob-attribute="true"]'
+  end
+
   test "should raise an exception when resolving nonexistent assets" do
     exception = assert_raises ActionView::Template::Error do
       get sample_load_nonexistent_assets_url

--- a/test/propshaft_integration_test.rb
+++ b/test/propshaft_integration_test.rb
@@ -8,6 +8,7 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_select 'link[href="/assets/hello_world-4137140a.css"][data-custom-attribute="true"]'
     assert_select 'link[href="/assets/goodbye-b1dc9940.css"][data-custom-attribute="true"]'
+    assert_select 'link[href="/assets/library-86a3b7a9.css"][data-custom-attribute="true"]'
 
     assert_select 'script[src="/assets/hello_world-888761f8.js"]'
   end
@@ -17,6 +18,7 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_select 'link[href="/assets/hello_world-4137140a.css"][data-glob-attribute="true"]'
     assert_select 'link[href="/assets/goodbye-b1dc9940.css"][data-glob-attribute="true"]'
+    assert_select('link[href="/assets/library-86a3b7a9.css"][data-glob-attribute="true"]', count: 0)
   end
 
   test "should raise an exception when resolving nonexistent assets" do


### PR DESCRIPTION
Add caching to `stylesheet_link_tag :all` so we don't search the load path every time when the files haven't changed in production.

Add `stylesheet_link_tag :app` to grab just the css files from app/assets/stylesheets/**/*.css and not all the potential engine load paths that have been added as well.