### PR TITLE
Require active_support's delegation module (fix crash introduced in 0.9.0)

### DIFF
--- a/lib/propshaft.rb
+++ b/lib/propshaft.rb
@@ -1,5 +1,6 @@
 require "active_support"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/module/delegation"
 require "logger"
 
 module Propshaft


### PR DESCRIPTION
https://github.com/rails/propshaft/pull/188 caused an error when applications that don't load all of Rails first before loading Propshaft are started:

```
gems/ruby/3.3.0/gems/propshaft-0.9.0/lib/propshaft/compiler.rb:6:in `<class:Compiler>': undefined method `delegate' for class Propshaft::Compiler (NoMethodError)

  delegate :config, :load_path, to: :assembly
  ^^^^^^^^
Did you mean?  DelegateClass
        from gems/ruby/3.3.0/gems/propshaft-0.9.0/lib/propshaft/compiler.rb:4:in `<main>'
 
```

Propshaft appears to only load the ActiveSupport extensions it needs, which is great, but this one is now missing.

Alternatively, the use of `delgate` can be replaced with a method, but I have a sense that this change is more appropriate for this project.