### PR TITLE
Fix 404 for loading source maps with digests in url

### DIFF
--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -35,7 +35,7 @@ class Propshaft::Server
   private
     def extract_path_and_digest(env)
       full_path = Rack::Utils.unescape(env["PATH_INFO"].to_s.sub(/^\//, ""))
-      digest    = full_path[/-([0-9a-zA-Z]{7,128})\.(?!digested)[^.]+\z/, 1]
+      digest    = full_path[/-([0-9a-zA-Z]{7,128})\.(?!digested)([^.]|.map)+\z/, 1]
       path      = digest ? full_path.sub("-#{digest}", "") : full_path
 
       [ path, digest ]

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -35,6 +35,12 @@ class Propshaft::ServerTest < ActiveSupport::TestCase
     assert_equal 200, last_response.status
   end
 
+  test "serve a sourcemap" do
+    asset = @assembly.load_path.find("file-is-a-sourcemap.js.map")
+    get "/#{asset.digested_path}"
+    assert_equal 200, last_response.status
+  end
+
   test "not found" do
     get "/not-found.js"
 


### PR DESCRIPTION
See reported issue #193.

Bisecting on v0.8 shows regression introduced in #171.