### PR TITLE
Add support to override manifest_path as a configuration

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -19,8 +19,8 @@ class Propshaft::Assembly
   end
 
   def resolver
-    @resolver ||= if manifest_path.exist?
-      Propshaft::Resolver::Static.new manifest_path: manifest_path, prefix: config.prefix
+    @resolver ||= if config.manifest_path.exist?
+      Propshaft::Resolver::Static.new manifest_path: config.manifest_path, prefix: config.prefix
     else
       Propshaft::Resolver::Dynamic.new load_path: load_path, prefix: config.prefix
     end
@@ -32,7 +32,7 @@ class Propshaft::Assembly
 
   def processor
     Propshaft::Processor.new \
-      load_path: load_path, output_path: config.output_path, compilers: compilers
+      load_path: load_path, output_path: config.output_path, compilers: compilers, manifest_path: config.manifest_path.manifest_path
   end
 
   def compilers
@@ -51,9 +51,4 @@ class Propshaft::Assembly
       asset.send(path_type)
     end
   end
-
-  private
-    def manifest_path
-      config.output_path.join(Propshaft::Processor::MANIFEST_FILENAME)
-    end
 end

--- a/lib/propshaft/processor.rb
+++ b/lib/propshaft/processor.rb
@@ -1,12 +1,11 @@
 require "propshaft/output_path"
 
 class Propshaft::Processor
-  MANIFEST_FILENAME = ".manifest.json"
+  attr_reader :load_path, :output_path, :compilers, :manifest_path
 
-  attr_reader :load_path, :output_path, :compilers
-
-  def initialize(load_path:, output_path:, compilers:)
+  def initialize(load_path:, output_path:, compilers:, manifest_path:)
     @load_path, @output_path = load_path, output_path
+    @manifest_path = manifest_path
     @compilers = compilers
   end
 
@@ -31,7 +30,8 @@ class Propshaft::Processor
 
 
     def write_manifest
-      File.open(output_path.join(MANIFEST_FILENAME), "wb+") do |manifest|
+      FileUtils.mkdir_p(File.dirname(manifest_path))
+      File.open(manifest_path, "wb+") do |manifest|
         manifest.write load_path.manifest.to_json
       end
     end

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -34,6 +34,7 @@ module Propshaft
       config.assets.relative_url_root ||= app.config.relative_url_root
       config.assets.output_path ||=
         Pathname.new(File.join(app.config.paths["public"].first, app.config.assets.prefix))
+      config.assets.manifest_path ||= config.assets.output_path.join(".manifest.json")
 
       app.assets = Propshaft::Assembly.new(app.config.assets)
 

--- a/test/propshaft/assembly_test.rb
+++ b/test/propshaft/assembly_test.rb
@@ -6,6 +6,7 @@ class Propshaft::AssemblyTest < ActiveSupport::TestCase
   test "uses static resolver when manifest is present" do
     assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config| 
       config.output_path = Pathname.new("#{__dir__}/../fixtures/output")
+      config.manifest_path = config.output_path.join(".manifest.json")
       config.prefix = "/assets"
     })
 
@@ -15,6 +16,7 @@ class Propshaft::AssemblyTest < ActiveSupport::TestCase
   test "uses dynamic resolver when manifest is missing" do
     assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config| 
       config.output_path = Pathname.new("#{__dir__}/../fixtures/assets")
+      config.manifest_path = config.output_path.join(".manifest.json")
       config.prefix = "/assets"
     })
 
@@ -24,6 +26,7 @@ class Propshaft::AssemblyTest < ActiveSupport::TestCase
   test "costly methods are memoized" do
     assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config|
       config.output_path = Pathname.new("#{__dir__}/../fixtures/assets")
+      config.manifest_path = config.output_path.join(".manifest.json")
       config.prefix = "/assets"
     })
 

--- a/test/propshaft/processor_test.rb
+++ b/test/propshaft/processor_test.rb
@@ -42,9 +42,10 @@ class Propshaft::ProcessorTest < ActiveSupport::TestCase
   private
     def processed
       Dir.mktmpdir do |output_path|
+        output_path = Pathname.new(output_path)
         processor = Propshaft::Processor.new(
-          load_path: @assembly.load_path, output_path: Pathname.new(output_path),
-          compilers: @assembly.compilers
+          load_path: @assembly.load_path, output_path: output_path,
+          compilers: @assembly.compilers, manifest_path: output_path.join(".manifest.json")
         )
 
         processor.process


### PR DESCRIPTION
## What is the problem this is solving?

The current implementation has a hardcoded manifest path making it difficult to adapt to various deployment scenarios.

In my scenario, a Docker image needs to be be built for the application to be deployed. The build process works as follows:
- The `public/assets` directory is cached across builds by default.
- `public/assets` is mounted at the beginning of the image build process.
- `rails assets:precompile` is executed.
- Other steps are executed that are not pertinent.
- Files in `public/assets` are uploaded to a cloud bucket.
- `public/assets` is unmounted.
- The directory is no longer available.
- The docker image is pushed to the registry.

When the docker container is started in a production environment, the `public/assets` folder does not exist in the local path as all the files are served through the CDN. This causes Propshaft [to use the Dynamic resolver](https://github.com/rails/propshaft/blob/main/lib/propshaft/assembly.rb#L22-L26), which needs to compute all asset digests at runtime.

The code changes prevents Propshaft from using the Dynamic resolver and allows the Static resolver to be used even if `public/assets` is absent in the local path which is ideal for setups where assets are served via CDN.