### PR TITLE
Fix deprecation in engine mounting

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -39,7 +39,7 @@ module Propshaft
 
       if config.assets.server
         app.routes.prepend do
-          mount app.assets.server => app.assets.config.prefix
+          mount app.assets.server, at: app.assets.config.prefix
         end
       end
 


### PR DESCRIPTION
Rails has marked mounting with hash syntax as a deprecation with removal coming in Rails 8.1 in https://github.com/rails/rails/pull/52422.  This PR clears that deprecation.