### PR TITLE
Add release workflow using Trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      id-token: write
+
+    environment: release
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: 3.3.4
+    - name: Configure trusted publishing credentials
+      uses: rubygems/configure-rubygems-credentials@v1.0.0
+    - name: Run release rake task
+      run: bundle exec rake release
+      shell: bash
+    - name: Wait for release to propagate
+      run: gem exec rubygems-await pkg/*.gem
+      shell: bash

--- a/bin/release
+++ b/bin/release
@@ -14,6 +14,3 @@ git commit -m "Bump version for $VERSION"
 git push
 git tag v$VERSION
 git push --tags
-gem build propshaft.gemspec
-gem push "propshaft-$VERSION.gem" --host https://rubygems.org
-rm "propshaft-$VERSION.gem"


### PR DESCRIPTION
Releasing is done now by publishing a new release on GitHub.