### PR TITLE
Ensure manifest_path is read from config properly by Assembly

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -32,7 +32,7 @@ class Propshaft::Assembly
 
   def processor
     Propshaft::Processor.new \
-      load_path: load_path, output_path: config.output_path, compilers: compilers, manifest_path: config.manifest_path.manifest_path
+      load_path: load_path, output_path: config.output_path, compilers: compilers, manifest_path: config.manifest_path
   end
 
   def compilers

--- a/test/propshaft/assembly_test.rb
+++ b/test/propshaft/assembly_test.rb
@@ -33,4 +33,14 @@ class Propshaft::AssemblyTest < ActiveSupport::TestCase
     assert_equal assembly.resolver.object_id, assembly.resolver.object_id
     assert_equal assembly.load_path.object_id, assembly.load_path.object_id
   end
+
+  test "instantiates a valid processor" do
+    assembly = Propshaft::Assembly.new(ActiveSupport::OrderedOptions.new.tap { |config|
+      config.output_path = Pathname.new("#{__dir__}/../fixtures/assets")
+      config.manifest_path = config.output_path.join(".manifest.json")
+      config.prefix = "/assets"
+    })
+
+    assert assembly.processor.is_a?(Propshaft::Processor)
+  end
 end


### PR DESCRIPTION
Ran into the following error attempting to utilize propshaft main (caused by simple typo):

![image](https://github.com/user-attachments/assets/3811b27b-fe20-4bbb-852b-204a990601c7)

Test likely isn't necessary to keep, but I needed it to reproduce the issue.
