### PR TITLE
Require propshaft before railtie

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -1,5 +1,6 @@
 require "rails"
 require "active_support/ordered_options"
+require "propshaft"
 require "propshaft/quiet_assets"
 
 module Propshaft


### PR DESCRIPTION
In Railties test suite, we explicitly add require "propshaft/railtie" to the application.rb.

rails/rails@5617c997 fixed most of the test failures in that branch.

This is similar to what Sprockets used to do:
https://github.com/rails/sprockets-rails/blob/2c04236faaacd021b7810289cbac93e962ff14da/lib/sprockets/railtie.rb#L6

Without requiring Propshaft first, we run into this type of error:

```
/home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-0.9.0/lib/propshaft/quiet_assets.rb:1:in `<top (required)>': uninitialized constant Propshaft (NameError)

class Propshaft::QuietAssets
      ^^^^^^^^^
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-0.9.0/lib/propshaft/railtie.rb:3:in `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
        from /home/zzak/code/rails/tmp/d20240912-3742241-z13n0d/app/config/application.rb:7:in `block in <top (required)>'
        from /home/zzak/code/rails/tmp/d20240912-3742241-z13n0d/app/config/application.rb:7:in `each'
        from /home/zzak/code/rails/tmp/d20240912-3742241-z13n0d/app/config/application.rb:7:in `<top (required)>'
        from /home/zzak/code/rails/tmp/d20240912-3742241-z13n0d/app/config/environment.rb:2:in `require_relative'
        from /home/zzak/code/rails/tmp/d20240912-3742241-z13n0d/app/config/environment.rb:2:in `<top (required)>'
        from /home/zzak/code/rails/tmp/d20240912-3742241-z13n0d/app/test/test_helper.rb:2:in `require_relative'
        from /home/zzak/code/rails/tmp/d20240912-3742241-z13n0d/app/test/test_helper.rb:2:in `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
        from test/models/post_test.rb:1:in `<main>'
```