### PR TITLE
Prioritize app assets over engine assets

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -32,6 +32,7 @@ module Propshaft
     end
 
     config.after_initialize do |app|
+      config.assets.paths.sort_by! { |path| path.to_s.start_with?(Rails.root.to_s) ? 0 : 1 }
       config.assets.relative_url_root ||= app.config.relative_url_root
       config.assets.output_path ||=
         Pathname.new(File.join(app.config.paths["public"].first, app.config.assets.prefix))

--- a/test/dummy/app/views/sample/load_real_assets.html.erb
+++ b/test/dummy/app/views/sample/load_real_assets.html.erb
@@ -4,3 +4,4 @@
 <p>Find me in app/views/sample/load_real_assets.html.erb</p>
 
 <%= javascript_include_tag "hello_world" %>
+<%= javascript_include_tag "actioncable" %>

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -11,7 +11,7 @@ require "action_controller/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require "action_view/railtie"
-# require "action_cable/engine"
+require "action_cable/engine"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
 

--- a/test/dummy/lib/assets/javascripts/actioncable.js
+++ b/test/dummy/lib/assets/javascripts/actioncable.js
@@ -1,0 +1,1 @@
+console.log("actioncable.js")

--- a/test/propshaft_integration_test.rb
+++ b/test/propshaft_integration_test.rb
@@ -13,6 +13,12 @@ class PropshaftIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'script[src="/assets/hello_world-888761f8.js"]'
   end
 
+  test "should prioritize app assets over engine assets" do
+    get sample_load_real_assets_url
+
+    assert_select 'script[src="/assets/actioncable-2e7de4f9.js"]'
+  end
+
   test "should find app styles via glob" do
     get sample_load_real_assets_url
 


### PR DESCRIPTION
Make the app assets always have priority when resolving them, if there is another asset with the same name in a gem. For example:

```bash
bin/importmap pin trix
```

You would have a `vendor/javascript/trix.js` file. If you call "trix" from importmap, it would still take the one from Action Text gem instead. Not anymore.