### PR TITLE
Add Propshaft::Compiler::JsAssetUrls

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -5,6 +5,7 @@ require "propshaft/server"
 require "propshaft/processor"
 require "propshaft/compilers"
 require "propshaft/compiler/css_asset_urls"
+require "propshaft/compiler/js_asset_urls"
 require "propshaft/compiler/source_mapping_urls"
 
 class Propshaft::Assembly

--- a/lib/propshaft/compiler/js_asset_urls.rb
+++ b/lib/propshaft/compiler/js_asset_urls.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "propshaft/compiler"
+
+class Propshaft::Compiler::JsAssetUrls < Propshaft::Compiler
+  ASSET_URL_PATTERN = %r{RAILS_ASSET_URL\(\s*["']?(?!(?:\#|%23|data|http|//))([^"'\s?#)]+)([#?][^"')]+)?\s*["']?\)}
+
+  def compile(asset, input)
+    input.gsub(ASSET_URL_PATTERN) { asset_url(resolve_path(asset.logical_path.dirname, $1), asset.logical_path, $2, $1) }
+  end
+
+  def referenced_by(asset, references: Set.new)
+    asset.content.scan(ASSET_URL_PATTERN).each do |referenced_asset_url, _|
+      referenced_asset = load_path.find(resolve_path(asset.logical_path.dirname, referenced_asset_url))
+
+      if referenced_asset && references.exclude?(referenced_asset)
+        references << referenced_asset
+        references.merge referenced_by(referenced_asset, references: references)
+      end
+    end
+
+    references
+  end
+
+  private
+    def resolve_path(directory, filename)
+      if filename.start_with?("../")
+        Pathname.new(directory + filename).relative_path_from("").to_s
+      elsif filename.start_with?("/")
+        filename.delete_prefix("/").to_s
+      else
+        (directory + filename.delete_prefix("./")).to_s
+      end
+    end
+
+    def asset_url(resolved_path, logical_path, fingerprint, pattern)
+      asset = load_path.find(resolved_path)
+      if asset
+        %["#{url_prefix}/#{asset.digested_path}#{fingerprint}"]
+      else
+        Propshaft.logger.warn("Unable to resolve '#{pattern}' for missing asset '#{resolved_path}' in #{logical_path}")
+        %["#{pattern}"]
+      end
+    end
+end

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -14,7 +14,8 @@ module Propshaft
     config.assets.compilers      = [
       [ "text/css", Propshaft::Compiler::CssAssetUrls ],
       [ "text/css", Propshaft::Compiler::SourceMappingUrls ],
-      [ "text/javascript", Propshaft::Compiler::SourceMappingUrls ]
+      [ "text/javascript", Propshaft::Compiler::JsAssetUrls ],
+      [ "text/javascript", Propshaft::Compiler::SourceMappingUrls ],
     ]
     config.assets.sweep_cache = Rails.env.development?
     config.assets.server = Rails.env.development? || Rails.env.test?

--- a/test/propshaft/compiler/js_asset_urls_test.rb
+++ b/test/propshaft/compiler/js_asset_urls_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+require "minitest/mock"
+require "propshaft/asset"
+require "propshaft/assembly"
+require "propshaft/compilers"
+
+require "propshaft/compiler/js_asset_urls"
+
+module Propshaft
+  class Compiler
+    class JsAssetUrlsTest < ActiveSupport::TestCase
+      setup do
+        @options = ActiveSupport::OrderedOptions.new.tap do |config|
+          config.paths = [Pathname.new("#{__dir__}/../../fixtures/assets/vendor")]
+          config.output_path = Pathname.new("#{__dir__}/../../fixtures/output")
+          config.prefix = "/assets"
+        end
+      end
+
+      test "the asset exists" do
+        js_content = <<~JS
+          export default class extends Controller {
+            init() {
+              this.img = RAILS_ASSET_URL("/foobar/source/file.svg");
+            }
+          }
+        JS
+
+        compiled = compile_asset_with_content(js_content)
+
+        assert_match(%r{this\.img = "/assets/foobar/source/file-[a-z0-9]{8}.svg"\;}, compiled)
+      end
+
+      test "the asset does not exist" do
+        js_content = <<~JS
+          export default class extends Controller {
+            init() {
+              this.img = RAILS_ASSET_URL("missing.svg");
+            }
+          }
+        JS
+
+        compiled = compile_asset_with_content(js_content)
+
+        assert_match(/this\.img = "missing.svg"\;/, compiled)
+      end
+
+      private
+
+      def compile_asset_with_content(content)
+        # This has one more set of .. than it would in the propshaft repo
+        root_path    = Pathname.new("#{__dir__}/../../fixtures/assets/vendor")
+        logical_path = "foobar/source/test.js"
+
+        assembly = Propshaft::Assembly.new(@options)
+        assembly.compilers.register("text/javascript", Propshaft::Compiler::JsAssetUrls)
+
+        asset = Propshaft::Asset.new(root_path.join(logical_path), logical_path: logical_path, load_path: assembly.load_path)
+        asset.stub(:content, content) do
+          assembly.compilers.compile(asset)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Not sure if this would just be better as a gem if the use case is simply not common enough, but I thought I'd see.

I recently found myself working on some javascript that needed to be able to reference a variety of images from our assets, but couldn't reliably do that because of the asset digest change to the filename. The solution for handling this in CSS works great and I wanted something similar for our javascript.

This compiler is almost 100% the same as the css asset compiler with the only real changes being to the regex and how assets that aren't in the load path are handled.