### PR TITLE
Revert "Require propshaft before railtie"

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -1,6 +1,5 @@
 require "rails"
 require "active_support/ordered_options"
-require "propshaft"
 require "propshaft/quiet_assets"
 
 module Propshaft


### PR DESCRIPTION
Reverts rails/propshaft#205. Causing issues with circular dependency as identified by @yahonda.