### PR TITLE
[Regression] Use stable sort when prioritizing app assets

### DIFF
--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -33,7 +33,7 @@ module Propshaft
 
     config.after_initialize do |app|
       # Prioritize assets from within the application over assets of the same path from engines/gems.
-      config.assets.paths.sort_by! { |path| path.to_s.start_with?(Rails.root.to_s) ? 0 : 1 }
+      config.assets.paths.sort_by!.with_index { |path, i| [path.to_s.start_with?(Rails.root.to_s) ? 0 : 1, i] }
 
       config.assets.relative_url_root ||= app.config.relative_url_root
       config.assets.output_path ||=


### PR DESCRIPTION
This fixes a regression introduced in #206. 

`sort_by!` doesn't preserve the original order so this loses the original order. https://ruby-doc.org/3.3.5/Array.html#method-i-sort_by-21
> For duplicates returned by the block, the ordering is indeterminate, and may be unstable.

I ran into this using esbuild and had `app/assets/builds` as the first entry in paths. After #206, `app/javascript` always ended up higher priority than `app/assets/builds` so it was finding the wrong file.