### PR TITLE
Handle source maps for nested assets where sourceMappingURL contains the subdirectory

### DIFF
--- a/lib/propshaft/compiler/source_mapping_urls.rb
+++ b/lib/propshaft/compiler/source_mapping_urls.rb
@@ -11,7 +11,7 @@ class Propshaft::Compiler::SourceMappingUrls < Propshaft::Compiler
 
   private
     def asset_path(source_mapping_url, logical_path)
-      source_mapping_url.gsub!(/^(.+\/)?#{url_prefix}\//, "")
+      source_mapping_url = ::File.basename(source_mapping_url)
 
       if logical_path.dirname.to_s == "."
         source_mapping_url

--- a/test/fixtures/assets/mapped/nested/sourceMappingURL-already-prefixed-nested-with-subdirectory.js
+++ b/test/fixtures/assets/mapped/nested/sourceMappingURL-already-prefixed-nested-with-subdirectory.js
@@ -1,0 +1,1 @@
+var fun; //# sourceMappingURL=/assets/nested/sourceMappingURL-already-prefixed-nested-with-subdirectory.js.map

--- a/test/propshaft/compiler/source_mapping_urls_test.rb
+++ b/test/propshaft/compiler/source_mapping_urls_test.rb
@@ -58,6 +58,8 @@ class Propshaft::Compiler::SourceMappingUrlsTest < ActiveSupport::TestCase
                  compile_asset(find_asset("sourceMappingURL-already-prefixed.js", fixture_path: "mapped"))
     assert_match %r{//# sourceMappingURL=/assets/nested/sourceMappingURL-already-prefixed-nested-[a-z0-9]{8}\.js\.map},
                  compile_asset(find_asset("nested/sourceMappingURL-already-prefixed-nested.js", fixture_path: "mapped"))
+    assert_match %r{//# sourceMappingURL=/assets/nested/sourceMappingURL-already-prefixed-nested-with-subdirectory-[a-z0-9]{8}\.js\.map},
+                 compile_asset(find_asset("nested/sourceMappingURL-already-prefixed-nested-with-subdirectory.js", fixture_path: "mapped"))
   end
 
   test "sourceMapURL is already prefixed with an incorrect url_prefix" do


### PR DESCRIPTION
We're using esbuild to compile our assets, and we have two separate application.css files - "application.css" and "javascript/application.css".

We've configured esbuild to have publicPath of "/assets", and we're seeing that the sourceMappingURL is correct for "application.css" but incorrect for "javascript/application.css".

Here's what the results of my testing was:
```
# no publicPath set in esbuild config
app/assets/builds/application.css => /*# sourceMappingURL=application.css.map */
app/assets/builds/javascript/application.css => /*# sourceMappingURL=application.css.map */
public/assets/application-ee89888f.css => /*# sourceMappingURL=/assets/application-2242cc06.css.map */
public/assets/javascript/application-7ca550ac.css => /*# sourceMappingURL=/assets/javascript/application-366197c5.css.map */

# publicPath: "assets" in esbuild config
WARNING LOGS: Removed sourceMappingURL comment for missing asset 'javascript/assets/javascript/application.css.map' from javascript/application.css

app/assets/builds/application.css => /*# sourceMappingURL=application.css.map */
app/assets/builds/javascript/application.css => /*# sourceMappingURL=assets/javascript/application.css.map */
public/assets/application-ee89888f.css => /*# sourceMappingURL=/assets/application-2242cc06.css.map */
public/assets/javascript/application-da8cc934.css => EMPTY

# publicPath: "/assets" in esbuild config
WARNING LOGS: Removed sourceMappingURL comment for missing asset 'javascript/javascript/application.css.map' from javascript/application.css

app/assets/builds/application.css => /*# sourceMappingURL=application.css.map */
app/assets/builds/javascript/application.css => /*# sourceMappingURL=/assets/javascript/application.css.map */
public/assets/application-ee89888f.css => /*# sourceMappingURL=/assets/application-2242cc06.css.map */
public/assets/javascript/application-57c47cf6.css => EMPTY
```

Note how it's basically joining the directories twice when publicPath is supplied (resulting in "javascript/javascript/application.css.map" which is invalid.

Given how in the case of no publicPath the sourceMappingURL just contains the basename of the asset map, it seems to me it's safe to get the basename from sourceMappingURL and then search for that file in the directory where the asset is - this will work as long as the asset and its map are **in the same directory**. I am not sure whether this is always the case, but it seems reasonable. Would be good for someone with more knowledge on this topic to pipe in!

This is based on the work done in https://github.com/rails/propshaft/pull/170.