### PR TITLE
devcontainer: bump ruby version from 2-bullseye to 3-bullseye

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
-ARG VARIANT=2-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
+ARG VARIANT=3-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
-ARG VARIANT=2-bullseye
+ARG VARIANT=3-bullseye
 FROM ruby:${VARIANT}
 
 # Copy library scripts to execute

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3-bullseye",
+			// "VARIANT": "3-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}


### PR DESCRIPTION
Bump Ruby version for the devcontainer from `2-bullseye` to `3-bullseye`.

To test:

```
> devcontainer build --workspace-folder .
# ... no errors ...
> devcontainer up --workspace-folder .
> devcontainer exec --workspace-folder . -- ruby --version
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [aarch64-linux]
```

Tests can then be run using:

```
devcontainer exec --workspace-folder . -- bundle install
devcontainer exec --workspace-folder . -- rake
```
