### PR TITLE
Add quotes to etags

### DIFF
--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -18,7 +18,7 @@ class Propshaft::Server
           Rack::CONTENT_LENGTH  => compiled_content.length.to_s,
           Rack::CONTENT_TYPE    => asset.content_type.to_s,
           VARY                  => "Accept-Encoding",
-          Rack::ETAG            => asset.digest,
+          Rack::ETAG            => "\"#{asset.digest}\"",
           Rack::CACHE_CONTROL   => "public, max-age=31536000, immutable"
         },
         [ compiled_content ]

--- a/test/propshaft/server_test.rb
+++ b/test/propshaft/server_test.rb
@@ -23,7 +23,7 @@ class Propshaft::ServerTest < ActiveSupport::TestCase
     assert_equal "62", last_response.headers['content-length']
     assert_equal "text/css", last_response.headers['content-type']
     assert_equal "Accept-Encoding", last_response.headers['vary']
-    assert_equal asset.digest, last_response.headers['etag']
+    assert_equal "\"#{asset.digest}\"", last_response.headers['etag']
     assert_equal "public, max-age=31536000, immutable", last_response.headers['cache-control']
     assert_equal ".hero { background: url(\"/foobar/source/file-3e6a1297.jpg\") }\n",
                  last_response.body


### PR DESCRIPTION
This PR fixes etag generation in Propshaft::Server.

In contrast to other headers, etags must be quoted. (See [RFC 9110 §8.8.3](https://www.rfc-editor.org/rfc/rfc9110.html#name-etag).)

Before:  
`etag: fa74dbac`
After:   
`etag: "fa74dbac"`