### PR TITLE
Read asset content in binary mode to suppress CRLF conversion on Windows

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -18,7 +18,7 @@ class Propshaft::Asset
   end
 
   def content(encoding: "ASCII-8BIT")
-    File.read(path, encoding: encoding)
+    File.read(path, encoding: encoding, mode: "rb")
   end
 
   def content_type


### PR DESCRIPTION
The first eight bytes of a PNG file always contain the following hex values: `89 50 4e 47 0d 0a 1a 0a`.

However,  `Asset#content` reads the file in text mode, and when using Propshaft on Windows, the first eight bytes become `89 50 4e 47 0a 1a 0a 00`.

As a result, the browser shows: _The image "..." cannot be displayed because it contains errors._

This PR adds the `mode: "rb"` option to the `File.read` call to suppress the CRLF -> LF conversion on Windows.

The external encoding is not affected, because it is explicitly specified.

