### PR TITLE
Refactor to allow digest algorithm patching.

### DIFF
--- a/lib/propshaft/asset.rb
+++ b/lib/propshaft/asset.rb
@@ -30,7 +30,7 @@ class Propshaft::Asset
   end
 
   def digest
-    @digest ||= Digest::SHA1.hexdigest("#{content_with_compile_references}#{load_path.version}").first(8)
+    @digest ||= perform_digest("#{content_with_compile_references}#{load_path.version}")
   end
 
   def digested_path
@@ -56,5 +56,9 @@ class Propshaft::Asset
 
     def already_digested?
       logical_path.to_s =~ /-([0-9a-zA-Z_-]{7,128})\.digested/
+    end
+
+    def perform_digest(text)
+      Digest::SHA1.hexdigest(text).first(8)
     end
 end

--- a/test/propshaft/asset_test.rb
+++ b/test/propshaft/asset_test.rb
@@ -27,6 +27,19 @@ class Propshaft::AssetTest < ActiveSupport::TestCase
     assert_equal "f2e1ec14", find_asset("one.txt").digest
   end
 
+  test "digest override" do
+    original_digest = ::Propshaft::Asset.instance_method(:perform_digest)
+    module ::Propshaft
+      class Asset
+        def perform_digest(text)
+          Digest::SHA1.hexdigest(text).first(10)
+        end
+      end
+    end
+    assert_equal 10, find_asset("one.txt").digest.size
+    ::Propshaft::Asset.define_method(:perform_digest, original_digest)
+  end
+
   test "fresh" do
     assert find_asset("one.txt").fresh?("f2e1ec14")
     assert_not find_asset("one.txt").fresh?("e206c34f")


### PR DESCRIPTION
Hi,
I once tried to discuss the default digest length [on #169](https://github.com/rails/propshaft/issues/169), to no avail.
How about simply refactoring things around without behavioral changes?  

I extracted
~~~ruby
Digest::SHA1.hexdigest(text).first(8)
~~~
into a private method, allowing a stable way for monkey-patching without affecting the functionality.

This keeps the current algorithm and output length, the change is minimal, and no change to any of the existing tests.