### PR TITLE
Cleanup pre-digested versions

### DIFF
--- a/lib/propshaft/output_path.rb
+++ b/lib/propshaft/output_path.rb
@@ -25,11 +25,13 @@ class Propshaft::OutputPath
   def files
     Hash.new.tap do |files|
       all_files_from_tree(path).each do |file|
-        digested_path = file.relative_path_from(path)
-        logical_path, digest = Propshaft::Asset.extract_path_and_digest(digested_path.to_s)
+        digested_path = file.relative_path_from(path).to_s
 
-        files[digested_path.to_s] = {
-          logical_path: logical_path.to_s,
+        digest = digested_path[/-([0-9a-zA-Z]{7,128})\.(digested\.)?([^.]|.map)+\z/, 1]
+        logical_path = digest ? digested_path.sub("-#{digest}", "") : digested_path
+
+        files[digested_path] = {
+          logical_path: logical_path,
           digest: digest,
           mtime: File.mtime(file)
         }

--- a/test/fixtures/output/file-already-abcdefVWXYZ0123456789_-.digested.css
+++ b/test/fixtures/output/file-already-abcdefVWXYZ0123456789_-.digested.css
@@ -1,0 +1,5 @@
+/* this is css */
+
+.btn {
+    background-image: asset-path("archive.svg");
+}


### PR DESCRIPTION
This makes Propshaft responsible for `-[digest].digested` files in the output path. Propshaft copies them from the load path into the output path. So it should also clean them up (addressing #140).

I refrained from making `-[digest].digested` files into a `Propshaft::Asset`, because this proposal has less moving parts and @dhh doesn't want to invest in non-container setups were cleanup is needed at all.