### PR TITLE
Server should also sweep cache

### DIFF
--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -7,6 +7,7 @@ class Propshaft::Server
   end
 
   def call(env)
+    execute_cache_sweeper_if_updated
     path, digest = extract_path_and_digest(env)
 
     if (asset = @assembly.load_path.find(path)) && asset.fresh?(digest)
@@ -43,5 +44,9 @@ class Propshaft::Server
       VARY = "Vary"
     else
       VARY = "vary"
+    end
+
+    def execute_cache_sweeper_if_updated
+      Rails.application.assets.load_path.cache_sweeper.execute_if_updated
     end
 end


### PR DESCRIPTION
Closes #228
Closes #110

Finally figured out the problem. With puma on cluster mode, a page request might be served by worker 1, which will cause a sweep if there were updates, but served by the server on worker 2... which has not sweeped the cache yet. And since the request is hitting the `Server` instance, instead of a controller it will not cause a sweep.