### PR TITLE
Remove railties runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-      railties (>= 7.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/propshaft.rb
+++ b/lib/propshaft.rb
@@ -10,4 +10,4 @@ end
 require "propshaft/assembly"
 require "propshaft/errors"
 require "propshaft/helper"
-require "propshaft/railtie"
+require "propshaft/railtie" if defined?(Rails::Railtie)

--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -16,7 +16,7 @@ class Propshaft::Assembly
   end
 
   def load_path
-    @load_path ||= Propshaft::LoadPath.new(config.paths, compilers: compilers, version: config.version)
+    @load_path ||= Propshaft::LoadPath.new(config.paths, compilers: compilers, version: config.version, file_watcher: config.file_watcher)
   end
 
   def resolver
@@ -47,7 +47,7 @@ class Propshaft::Assembly
 
   def reveal(path_type = :logical_path)
     path_type = path_type.presence_in(%i[ logical_path path ]) || raise(ArgumentError, "Unknown path_type: #{path_type}")
-    
+
     load_path.assets.collect do |asset|
       asset.send(path_type)
     end

--- a/lib/propshaft/railtie.rb
+++ b/lib/propshaft/railtie.rb
@@ -35,6 +35,8 @@ module Propshaft
       # Prioritize assets from within the application over assets of the same path from engines/gems.
       config.assets.paths.sort_by!.with_index { |path, i| [path.to_s.start_with?(Rails.root.to_s) ? 0 : 1, i] }
 
+      config.assets.file_watcher ||= app.config.file_watcher
+
       config.assets.relative_url_root ||= app.config.relative_url_root
       config.assets.output_path ||=
         Pathname.new(File.join(app.config.paths["public"].first, app.config.assets.prefix))

--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -47,7 +47,6 @@ class Propshaft::Server
     end
 
     def execute_cache_sweeper_if_updated
-      return unless defined?(Rails)
-      Rails.application.assets.load_path.cache_sweeper.execute_if_updated
+      @assembly.load_path.cache_sweeper.execute_if_updated
     end
 end

--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -47,6 +47,7 @@ class Propshaft::Server
     end
 
     def execute_cache_sweeper_if_updated
+      return unless defined?(Rails)
       Rails.application.assets.load_path.cache_sweeper.execute_if_updated
     end
 end

--- a/propshaft.gemspec
+++ b/propshaft.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7.0"
   s.add_dependency "actionpack", ">= 7.0.0"
   s.add_dependency "activesupport", ">= 7.0.0"
-  s.add_dependency "railties", ">= 7.0.0"
   s.add_dependency "rack"
 
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.md"]


### PR DESCRIPTION
This library technically has no dependency on `railties` to function.

Only if the environment we're in defines `Railtie` (Ruby on Rails) we want to load Rails specific behavior, but at this point we can rely on the gem already being loaded.

Making this change enables us to make it actually work in a standalone Rack environment, without implicitly changing the behavior of other gems that try to load their own railties because of the dependency being loaded.