### PR TITLE
Only sweep the cache if cache sweeping is enabled.

### DIFF
--- a/lib/propshaft/server.rb
+++ b/lib/propshaft/server.rb
@@ -47,6 +47,8 @@ class Propshaft::Server
     end
 
     def execute_cache_sweeper_if_updated
-      @assembly.load_path.cache_sweeper.execute_if_updated
+      if @assembly.config.sweep_cache
+        @assembly.load_path.cache_sweeper.execute_if_updated
+      end
     end
 end


### PR DESCRIPTION
When trying to update to `1.2.0` we started getting consist errors in certain system tests that there were pending connections. I ran a bisect on `propshaft` and tracked it down to a change in 689e756689baa141291c7422f6a2df41b5ceead8 which looks like it may sweep the cache on every request for an asset (introduced in #232). Commenting out [the line](https://github.com/rails/propshaft/blob/74a07056fba7a5824bfcc34fb5972b81cfb6f96a/lib/propshaft/server.rb#L50) solved our immediate issue and got our test suite back to green.

Digging into this further it looks like cache sweeping would previously only occur when ActionController::Base was loaded and `config.assets.sweep_cache` was true ([see here](https://github.com/rails/propshaft/blob/74a07056fba7a5824bfcc34fb5972b81cfb6f96a/lib/propshaft/railtie.rb#L59)). By default `sweep_cache` is only set to true [in development](https://github.com/rails/propshaft/blob/74a07056fba7a5824bfcc34fb5972b81cfb6f96a/lib/propshaft/railtie.rb#L19). But cache sweeping was also being run consistently in our test environment. This appeared to manifest as assets consistently being regenerated which effectively doubled the runtime of our system tests and would cause some pages to take too long to fully render which failed the tests.

This pull request adds the same check to the server that `config.assets.sweep_cache` is enabled which was happening in the railtie. I am not sure if this change is compatible with using `propshaft` without Rails as I don't know if the config is available in that context.

Lastly, without this check there is a risk that cache sweeping is occurring in production.