### PR TITLE
Add option `:all_app_last` to `stylesheet_link_tag` helper

### DIFF
--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -68,8 +68,10 @@ module Propshaft
     #   # => <link rel="stylesheet" href="/assets/application-abc123.css"
     #   #          integrity="sha256-xyz789...">
     #
-    #   stylesheet_link_tag :all    # All stylesheets in load path
-    #   stylesheet_link_tag :app    # Only app/assets stylesheets
+    #   stylesheet_link_tag :all          # All stylesheets in load path
+    #   stylesheet_link_tag :app          # Only app/assets stylesheets
+    #   stylesheet_link_tag :all_app_last # All stylesheets in load path ensuring app/assets last,
+    #                                       so vendor and gem styles can safely be overwritten
     def stylesheet_link_tag(*sources)
       options = sources.extract_options!
 
@@ -78,6 +80,9 @@ module Propshaft
         sources = all_stylesheets_paths
       when :app
         sources = app_stylesheets_paths
+      when :all_app_last
+        app_paths = app_stylesheets_paths
+        sources = (all_stylesheets_paths - app_paths) + app_paths
       end
 
       _build_asset_tags(sources, options, :stylesheet) { |source, opts| super(source, opts) }

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -68,8 +68,10 @@ module Propshaft
     #   # => <link rel="stylesheet" href="/assets/application-abc123.css"
     #   #          integrity="sha256-xyz789...">
     #
-    #   stylesheet_link_tag :all    # All stylesheets in load path
-    #   stylesheet_link_tag :app    # Only app/assets stylesheets
+    #   stylesheet_link_tag :all          # All stylesheets in load path
+    #   stylesheet_link_tag :app          # Only app/assets stylesheets
+    #   stylesheet_link_tag :all_app_last # All stylesheets in load path ensuring app/assets last,
+    #                                       so vendor and gem styles can safely be overwritten
     def stylesheet_link_tag(*sources)
       options = sources.extract_options!
 
@@ -78,6 +80,9 @@ module Propshaft
         sources = all_stylesheets_paths
       when :app
         sources = app_stylesheets_paths
+      when :all_app_last
+        app_stylesheets_paths = app_stylesheets_paths
+        sources = (all_stylesheets_paths - app_stylesheets_paths) + app_stylesheets_paths
       end
 
       _build_asset_tags(sources, options, :stylesheet) { |source, opts| super(source, opts) }

--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -81,8 +81,8 @@ module Propshaft
       when :app
         sources = app_stylesheets_paths
       when :all_app_last
-        app_stylesheets_paths = app_stylesheets_paths
-        sources = (all_stylesheets_paths - app_stylesheets_paths) + app_stylesheets_paths
+        app_paths = app_stylesheets_paths
+        sources = (all_stylesheets_paths - app_paths) + app_paths
       end
 
       _build_asset_tags(sources, options, :stylesheet) { |source, opts| super(source, opts) }

--- a/test/propshaft/helper_test.rb
+++ b/test/propshaft/helper_test.rb
@@ -105,6 +105,16 @@ class Propshaft::HelperTest < ActionView::TestCase
     HTML
   end
 
+  test "stylesheet_link_tag with :all_app_last option" do
+    result = stylesheet_link_tag(:all_app_last)
+
+    assert_dom_equal(<<~HTML, result)
+      <link rel="stylesheet" href="/assets/library-86a3b7a9.css" />
+      <link rel="stylesheet" href="/assets/goodbye-b1dc9940.css" />
+      <link rel="stylesheet" href="/assets/hello_world-4137140a.css" />
+    HTML
+  end
+
   test "stylesheet_link_tag with :app option" do
     result = stylesheet_link_tag(:app)
 


### PR DESCRIPTION
We have tens of apps in our company that all use stylesheets from a common corporate design layout gem.
In some of these apps, custom styles are used, which partly overwrite existing styles from the layout gem.

However, without CSS bundling (which we intend to avoid), there is no clean way to ensure the app styles overwrite the styles from vendor and the gems (aka are loaded last).
The only obscure way is to name all local files like `zzzzzzzz_application.css` to make those last in the list generated by `stylesheet_link_tag :all`.

To remedy this, I have added the option `:all_app_last` so the stylesheet tags are generated vendor and gems first, app last so external styles can safely be overwritten in stylesheets under `app/assets`.

Is this feature desireable for a broader audience or is something like this already possible and I just missed it?