### PR TITLE
Support minitest 6 where possible, pin < 6 elsewhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,12 @@ jobs:
           - "7.1"
           - "7.2"
           - "8.0"
+          - "8.1"
         exclude:
           - ruby-version: "3.1"
             rails-version: "8.0"
+          - ruby-version: "3.1"
+            rails-version: "8.1"
       fail-fast: false
     env:
       BUNDLE_GEMFILE: gemfiles/Gemfile.rails-${{ matrix.rails-version }}

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "rails", ">= 7.0.1"
+gem "minitest-mock"
 gem "rake"
 gem "debug"

--- a/gemfiles/Gemfile.rails-7.0
+++ b/gemfiles/Gemfile.rails-7.0
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rails", github: "rails/rails", branch: "7-0-stable"
+gem "minitest", "< 6"
 gem "rake"
 gem "debug"

--- a/gemfiles/Gemfile.rails-7.2
+++ b/gemfiles/Gemfile.rails-7.2
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rails", "~> 7.2.0"
+gem "minitest-mock"
 gem "rake"
 gem "debug"

--- a/gemfiles/Gemfile.rails-8.0
+++ b/gemfiles/Gemfile.rails-8.0
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rails", "~> 8.0"
+gem "minitest-mock"
 gem "rake"
 gem "debug"

--- a/gemfiles/Gemfile.rails-8.1
+++ b/gemfiles/Gemfile.rails-8.1
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", "~> 7.1.0"
-gem "minitest", "< 6"
+gem "rails", "~> 8.1"
+gem "minitest-mock"
 gem "rake"
 gem "debug"


### PR DESCRIPTION
## Summary
- Minitest 6 extracted `minitest/mock` into a separate gem (`minitest-mock`), breaking `require "minitest/mock"` in tests
- **Rails 7.0, 7.1**: pin `minitest < 6` (these Rails versions don't constrain minitest themselves)
- **Rails 7.2**: no pin needed (already pins `minitest < 6` in its own gemspec, [rails/rails@6ea60702](https://github.com/rails/rails/commit/6ea60702))
- **Rails 8.0, 8.1, root Gemfile**: use minitest 6 with the `minitest-mock` gem
- Add Rails 8.1 to the CI matrix

## Test plan
- [x] `bin/test` passes against all five Rails Gemfiles (7.0, 7.1, 7.2, 8.0, 8.1) across Ruby 3.2, 3.3, and 3.4