### PR TITLE
Eagerly initialize Manifest in Resolver::Static

### DIFF
--- a/lib/propshaft/resolver/static.rb
+++ b/lib/propshaft/resolver/static.rb
@@ -5,7 +5,9 @@ module Propshaft::Resolver
     attr_reader :manifest_path, :prefix
 
     def initialize(manifest_path:, prefix:)
-      @manifest_path, @prefix = manifest_path, prefix
+      @manifest_path = manifest_path
+      @prefix = prefix
+      @manifest = Propshaft::Manifest.from_path(manifest_path)
     end
 
     def resolve(logical_path)
@@ -15,7 +17,7 @@ module Propshaft::Resolver
     end
 
     def integrity(logical_path)
-      entry = manifest[logical_path]
+      entry = @manifest[logical_path]
 
       entry&.integrity
     end
@@ -27,12 +29,8 @@ module Propshaft::Resolver
     end
 
     private
-      def manifest
-        @manifest ||= Propshaft::Manifest.from_path(manifest_path)
-      end
-
       def digested_path(logical_path)
-        entry = manifest[logical_path]
+        entry = @manifest[logical_path]
 
         entry&.digested_path
       end


### PR DESCRIPTION
Propshaft::Assembly lazily instantiates a Resolver based on whether a configured manifest path exists. In production environments (where assets are precompiled and the manifest does exist), the Static resolver is used, which lazily loads the manifest to resolve assets. This means the first request to the app will pay the cost of parsing the manifest.

This commit moves the Manifest instantiation to Static's initializer to reduce its laziness. The Resolver itself is still instantiated lazily, but that will be addressed in a future commit.