### PR TITLE
Look up :all stylesheets through the resolver

### DIFF
--- a/lib/propshaft/helper.rb
+++ b/lib/propshaft/helper.rb
@@ -29,7 +29,7 @@ module Propshaft
   # == Bulk Stylesheet Inclusion
   #
   # The stylesheet_link_tag helper supports special symbols for bulk inclusion:
-  # - :all - includes all CSS files found in the load path
+  # - :all - includes all CSS files known to the asset resolver
   # - :app - includes only CSS files from app/assets/**/*.css
   #
   #   <%= stylesheet_link_tag :all %>  # All stylesheets
@@ -57,7 +57,7 @@ module Propshaft
     # In addition to the standard Rails functionality, this method supports:
     # * Automatic SRI (Subresource Integrity) hash generation in secure contexts
     # * Add an option to call +stylesheet_link_tag+ with +:all+ to include every css
-    #   file found on the load path or +:app+ to include css files found in
+    #   file known to the asset resolver or +:app+ to include css files found in
     #   <tt>Rails.root("app/assets/**/*.css")</tt>, which will exclude lib/ and plugins.
     #
     # ==== Options
@@ -70,7 +70,7 @@ module Propshaft
     #   # => <link rel="stylesheet" href="/assets/application-abc123.css"
     #   #          integrity="sha256-xyz789...">
     #
-    #   stylesheet_link_tag :all    # All stylesheets in load path
+    #   stylesheet_link_tag :all    # All stylesheets known to the resolver
     #   stylesheet_link_tag :app    # Only app/assets stylesheets
     def stylesheet_link_tag(*sources)
       options = sources.extract_options!
@@ -105,9 +105,9 @@ module Propshaft
       _build_asset_tags(sources, options, :javascript) { |source, opts| super(source, opts) }
     end
 
-    # Returns a sorted and unique array of logical paths for all stylesheets in the load path.
+    # Returns a sorted and unique array of logical paths for all stylesheets known to the resolver.
     def all_stylesheets_paths
-      Rails.application.assets.load_path.asset_paths_by_type("css")
+      Rails.application.assets.resolver.asset_paths_by_type("css")
     end
 
     # Returns a sorted and unique array of logical paths for all stylesheets in app/assets/**/*.css.

--- a/lib/propshaft/manifest.rb
+++ b/lib/propshaft/manifest.rb
@@ -136,6 +136,17 @@ module Propshaft
       @entries[logical_path]
     end
 
+    # Groups the logical paths of every entry in the manifest by content type.
+    #
+    # Entries with an unrecognized extension are grouped under +nil+.
+    #
+    # ==== Returns
+    #
+    # A hash of <tt>Mime::Type => [ logical_path ]</tt>, with each array sorted.
+    def logical_paths_by_content_type
+      @entries.keys.sort.group_by { |logical_path| content_type_for(logical_path) }
+    end
+
     # Removes a manifest entry by its logical path.
     #
     # ==== Parameters
@@ -181,5 +192,9 @@ module Propshaft
 
     private
       attr_reader :integrity_hash_algorithm
+
+      def content_type_for(logical_path)
+        Mime::Type.lookup_by_extension(File.extname(logical_path).delete_prefix("."))
+      end
   end
 end

--- a/lib/propshaft/resolver/dynamic.rb
+++ b/lib/propshaft/resolver/dynamic.rb
@@ -28,6 +28,10 @@ module Propshaft::Resolver
       end
     end
 
+    def asset_paths_by_type(extension)
+      load_path.asset_paths_by_type(extension)
+    end
+
     private
       def find_asset(logical_path)
         load_path.find(logical_path)

--- a/lib/propshaft/resolver/static.rb
+++ b/lib/propshaft/resolver/static.rb
@@ -8,6 +8,7 @@ module Propshaft::Resolver
       @manifest_path = manifest_path
       @prefix = prefix
       @manifest = Propshaft::Manifest.from_path(manifest_path)
+      @logical_paths_by_content_type = @manifest.logical_paths_by_content_type
     end
 
     def resolve(logical_path)
@@ -26,6 +27,10 @@ module Propshaft::Resolver
       if asset_path = digested_path(logical_path)
         File.read(manifest_path.dirname.join(asset_path), encoding: encoding)
       end
+    end
+
+    def asset_paths_by_type(extension)
+      @logical_paths_by_content_type[Mime::Type.lookup_by_extension(extension)] || []
     end
 
     private

--- a/test/fixtures/output/.manifest.json
+++ b/test/fixtures/output/.manifest.json
@@ -1,1 +1,1 @@
-{ "one.txt": "one-f2e1ec14.txt" }
+{ "one.txt": "one-f2e1ec14.txt", "hello_world.js": "hello_world-888761f8.js", "styles/print.css": "styles/print-1a2b3c4d.css", "hello_world.css": "hello_world-4137140a.css" }

--- a/test/propshaft/manifest_test.rb
+++ b/test/propshaft/manifest_test.rb
@@ -86,6 +86,36 @@ class Propshaft::ManifestTest < ActiveSupport::TestCase
     assert_nil retrieved_entry.integrity
   end
 
+  test "logical_paths_by_content_type groups sorted logical paths" do
+    manifest = create_manifest
+    manifest << css_entry("z.css")
+    manifest << css_entry("a.css")
+    manifest << css_entry("nested/m.css")
+
+    grouped = manifest.logical_paths_by_content_type
+
+    assert_equal [ "a.css", "another.css", "nested/m.css", "z.css" ], grouped[Mime::Type.lookup("text/css")]
+    assert_equal [ "one.txt" ], grouped[Mime::Type.lookup("text/plain")]
+    assert_nil grouped[Mime::Type.lookup("image/png")]
+  end
+
+  test "logical_paths_by_content_type groups unrecognized extensions under nil" do
+    manifest = create_manifest
+    manifest << Propshaft::Manifest::ManifestEntry.new(
+      logical_path: "source.js.map", digested_path: "source-abc123.js.map", integrity: nil
+    )
+
+    assert_equal [ "source.js.map" ], manifest.logical_paths_by_content_type[nil]
+  end
+
+  test "logical_paths_by_content_type reflects entries at the time it is called" do
+    manifest = create_manifest
+    assert_equal [ "another.css" ], manifest.logical_paths_by_content_type[Mime::Type.lookup("text/css")]
+
+    manifest.delete("another.css")
+    assert_nil manifest.logical_paths_by_content_type[Mime::Type.lookup("text/css")]
+  end
+
   test "[] accessor returns nil for missing entries" do
     manifest = Propshaft::Manifest.new
     assert_nil manifest["nonexistent.js"]
@@ -208,6 +238,12 @@ class Propshaft::ManifestTest < ActiveSupport::TestCase
         manifest.push_asset(find_asset("one.txt"))
         manifest.push_asset(find_asset("another.css"))
       end
+    end
+
+    def css_entry(logical_path, digested_path: "#{logical_path}-abc123.css")
+      Propshaft::Manifest::ManifestEntry.new(
+        logical_path: logical_path, digested_path: digested_path, integrity: nil
+      )
     end
 
     def find_asset(logical_path)

--- a/test/propshaft/resolver/static_test.rb
+++ b/test/propshaft/resolver/static_test.rb
@@ -28,6 +28,10 @@ module Propshaft::Resolver::StaticTests
       assert_nil resolver.resolve("nowhere.txt")
     end
 
+    test "asset paths by type returns empty array when no asset matches" do
+      assert_equal [], resolver.asset_paths_by_type("png")
+    end
+
     test "integrity for missing asset returns nil" do
       assert_nil resolver.integrity("nowhere.txt")
     end
@@ -52,6 +56,11 @@ end
 
 class Propshaft::Resolver::StaticTest < ActiveSupport::TestCase
   include Propshaft::Resolver::StaticTests
+
+  test "asset paths by type returns the paths for the extension's content type" do
+    assert_equal [ "hello_world.css", "styles/print.css" ], resolver.asset_paths_by_type("css")
+    assert_equal [ "hello_world.js" ], resolver.asset_paths_by_type("js")
+  end
 
   test "integrity for asset returns nil for simple manifest" do
     assert_nil resolver.integrity("one.txt")


### PR DESCRIPTION
Currently, `all_stylesheets_paths` asks `LoadPath` for every `text/css` asset, which requires walking every configured asset path and building an `Asset` for each file found. That work is unnecessary in production, where `Resolver::Static` otherwise resolves digested paths straight out of the precompiled `.manifest.json`.

This commit moves the lookup to the resolver, so `Resolver::Static` can use the manifest while `Resolver::Dynamic` delegates to to current `LoadPath` logic.

`:app` still needs the load path (for now), since it globs source paths that the manifest doesn't record.

Removing usage of the `LoadPath` in production helps get us closer to using `Propshaft::Assembly` inside a Ractor.