### PR TITLE
Fix assertionless tests in Resolver::StaticTest

### DIFF
--- a/test/propshaft/resolver/static_test.rb
+++ b/test/propshaft/resolver/static_test.rb
@@ -4,98 +4,80 @@ require "test_helper"
 require "minitest/mock"
 require "propshaft/resolver/static"
 
-class Propshaft::Resolver::StaticTest < ActiveSupport::TestCase
-  setup do
-    @resolver = Propshaft::Resolver::Static.new(
-      manifest_path: Pathname.new("#{__dir__}/../../fixtures/output/.manifest.json"),
-      prefix: "/assets"
-    )
-  end
+module Propshaft::Resolver::StaticTests
+  extend ActiveSupport::Concern
 
-  test "resolving present asset returns uri path" do
-    assert_equal \
-      "/assets/one-f2e1ec14.txt",
-      @resolver.resolve("one.txt")
-  end
-
-  test "reading static asset" do
-    assert_equal "ASCII-8BIT", @resolver.read("one.txt").encoding.to_s
-    assert_equal "One from first path", @resolver.read("one.txt")
-  end
-
-  test "reading static asset with encoding option" do
-    assert_equal "UTF-8", @resolver.read("one.txt", encoding: "UTF-8").encoding.to_s
-    assert_equal "One from first path", @resolver.read("one.txt", encoding: "UTF-8")
-  end
-
-  test "resolving missing asset returns nil" do
-    assert_nil @resolver.resolve("nowhere.txt")
-  end
-
-  test "integrity for asset returns nil for simple manifest" do
-    assert_nil @resolver.integrity("one.txt")
-  end
-
-  test "integrity for missing asset returns nil" do
-    assert_nil @resolver.integrity("nowhere.txt")
-  end
-
-  test "resolver requests json optimizer gems to keep parsed manifest keys as strings" do
-    stub = Proc.new do |_, opts|
-      assert_equal false, opts[:symbolize_names]
-      {}
-    end
-
-    JSON.stub :parse, stub do
-      @resolver.resolve("one.txt")
-    end
-  end
-
-  class Propshaft::Resolver::StaticTest::WithExtensibleManifest < ActiveSupport::TestCase
-    setup do
-      @resolver = Propshaft::Resolver::Static.new(
-        manifest_path: Pathname.new("#{__dir__}/../../fixtures/new_manifest_format/.manifest.json"),
-        prefix: "/assets"
-      )
-    end
-
+  included do
     test "resolving present asset returns uri path" do
       assert_equal \
         "/assets/one-f2e1ec14.txt",
-        @resolver.resolve("one.txt")
+        resolver.resolve("one.txt")
     end
 
     test "reading static asset" do
-      assert_equal "ASCII-8BIT", @resolver.read("one.txt").encoding.to_s
-      assert_equal "One from first path", @resolver.read("one.txt")
+      assert_equal "ASCII-8BIT", resolver.read("one.txt").encoding.to_s
+      assert_equal "One from first path", resolver.read("one.txt")
     end
 
     test "reading static asset with encoding option" do
-      assert_equal "UTF-8", @resolver.read("one.txt", encoding: "UTF-8").encoding.to_s
-      assert_equal "One from first path", @resolver.read("one.txt", encoding: "UTF-8")
+      assert_equal "UTF-8", resolver.read("one.txt", encoding: "UTF-8").encoding.to_s
+      assert_equal "One from first path", resolver.read("one.txt", encoding: "UTF-8")
     end
 
     test "resolving missing asset returns nil" do
-      assert_nil @resolver.resolve("nowhere.txt")
-    end
-
-    test "integrity for asset returns value from extensible manifest" do
-      assert_equal "sha384-LdS8l2QTAF8bD8WPb8QSQv0skTWHhmcnS2XU5LBkVQneGzqIqnDRskQtJvi7ADMe", @resolver.integrity("one.txt")
+      assert_nil resolver.resolve("nowhere.txt")
     end
 
     test "integrity for missing asset returns nil" do
-      assert_nil @resolver.integrity("nowhere.txt")
+      assert_nil resolver.integrity("nowhere.txt")
     end
 
     test "resolver requests json optimizer gems to keep parsed manifest keys as strings" do
+      called = false
+
       stub = Proc.new do |_, opts|
         assert_equal false, opts[:symbolize_names]
+        called = true
         {}
       end
 
       JSON.stub :parse, stub do
-        @resolver.resolve("one.txt")
+        resolver.resolve("one.txt")
       end
+
+      assert called
     end
   end
+end
+
+class Propshaft::Resolver::StaticTest < ActiveSupport::TestCase
+  include Propshaft::Resolver::StaticTests
+
+  test "integrity for asset returns nil for simple manifest" do
+    assert_nil resolver.integrity("one.txt")
+  end
+
+  private
+    def resolver
+      @resolver ||= Propshaft::Resolver::Static.new(
+        manifest_path: Pathname.new("#{__dir__}/../../fixtures/output/.manifest.json"),
+        prefix: "/assets"
+      )
+    end
+end
+
+class Propshaft::Resolver::StaticTest::WithExtensibleManifest < ActiveSupport::TestCase
+  include Propshaft::Resolver::StaticTests
+
+  test "integrity for asset returns value from extensible manifest" do
+    assert_equal "sha384-LdS8l2QTAF8bD8WPb8QSQv0skTWHhmcnS2XU5LBkVQneGzqIqnDRskQtJvi7ADMe", resolver.integrity("one.txt")
+  end
+
+  private
+    def resolver
+      @resolver ||= Propshaft::Resolver::Static.new(
+        manifest_path: Pathname.new("#{__dir__}/../../fixtures/new_manifest_format/.manifest.json"),
+        prefix: "/assets"
+      )
+    end
 end


### PR DESCRIPTION
These were introduced by my change to make Resolver::Static eagerly parse the manifest: the JSON.parse happens in the setup block before the stub takes effect.

Fix the issue by refactoring the test classes: extract duplicate tests to a concern, and change Resolver to be lazily created so that JSON.parse can be properly stubbed. Additionally, refactor the previously assertionless test so that it will fail instead of warn if this mistake is made again.