### PR TITLE
Eagerly load Resolver when assembly is frozen

### DIFF
--- a/lib/propshaft/assembly.rb
+++ b/lib/propshaft/assembly.rb
@@ -18,6 +18,11 @@ class Propshaft::Assembly
     @config = config
   end
 
+  def freeze
+    resolver
+    super
+  end
+
   def load_path
     @load_path ||= Propshaft::LoadPath.new(
       config.paths,


### PR DESCRIPTION
When Ractor.make_shareable is called on Rails.application, Propshaft::Assembly will be frozen because its stored as Rails.application.assets. Once frozen, none of its lazily initialized instance variables can be set.

Luckily, in a produciton environment where a manifest.json is present, the only instance variable needed on Assembly is Resolver (once #272 and #274 are resolved). Therefore, this commit touches the resolver when Assembly is frozen so that assets can be resolved from non-main Ractors (in production).