### PR TITLE
Add TODO for removing Mime.extensions fallback

### DIFF
--- a/lib/propshaft/load_path.rb
+++ b/lib/propshaft/load_path.rb
@@ -54,6 +54,7 @@ class Propshaft::LoadPath
   # and test to ensure the map caches are reset when javascript files are changed.
   def cache_sweeper
     @cache_sweeper ||= begin
+      # TODO: Remove respond_to? after Rails 8.1 support is dropped
       exts_to_watch  = Mime.respond_to?(:extensions) ? Mime.extensions : Mime::EXTENSION_LOOKUP.map(&:first)
       files_to_watch = Array(paths).collect { |dir| [ dir.to_s, exts_to_watch ] }.to_h
       mutex = Mutex.new


### PR DESCRIPTION
Once Rails 8.1 is no longer supported, the respond_to check can be removed